### PR TITLE
Replace EmptySet with Empty

### DIFF
--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -1,6 +1,9 @@
 // This package defines lemmas for sets commonly used in specifications.
 package sets
 
+// ##(-I ../)
+import utils "utils"
+
 // TODO Add proper attribution
 // SO Not taken from outside sources
 // S1 https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
@@ -12,23 +15,6 @@ package sets
 // TODO Improve comments
 // QUES Should we use unicode comments like ∀ x,y : set[int]. |x| ≤ |y|?
 
-// TODO Figure out how to import these from verify.gobra
-// SO
-// Helpers
-// *******
-type Unit struct{}
-
-ghost
-requires b
-decreases
-pure func Asserting(ghost b bool) Unit {
-	return Unit{}
-}
-
-ghost
-ensures false
-decreases _
-func TODO()
 
 // Empty set
 // *********
@@ -54,8 +40,8 @@ ghost
 requires xs == EmptySet()
 ensures IsEmpty(xs)
 decreases
-pure func EmptyLen(xs set[int]) Unit {
-	return Unit{}
+pure func EmptyLen(xs set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
@@ -64,8 +50,8 @@ ghost
 requires IsEmpty(xs)
 ensures xs == EmptySet()
 decreases
-pure func EmptyIsEmptySet(xs set[int]) Unit {
-	return Unit{}
+pure func EmptyIsEmptySet(xs set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3, S4
@@ -74,8 +60,8 @@ ghost
 requires IsEmpty(xs)
 ensures !(e in xs)
 decreases
-pure func NotInEmpty(xs set[int], e int) Unit {
-	return Unit{}
+pure func NotInEmpty(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // Singleton set
@@ -104,8 +90,8 @@ ghost
 requires xs == SingletonSet(e)
 ensures IsSingleton(xs)
 decreases
-pure func SingletonLen(xs set[int], e int) Unit {
-	return Unit{}
+pure func SingletonLen(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S0
@@ -115,8 +101,8 @@ requires IsSingleton(xs)
 requires e in xs
 ensures xs == SingletonSet(e)
 decreases
-pure func SingletonIsSingletonSet(xs set[int], e int) Unit {
-	return let _ := Choose(xs) in Unit{}
+pure func SingletonIsSingletonSet(xs set[int], e int) utils.Unit {
+	return let _ := Choose(xs) in utils.Unit{}
 }
 
 // S1
@@ -127,8 +113,8 @@ requires a in xs
 requires b in xs
 ensures a == b
 decreases
-pure func SingletonEquality(xs set[int], a int, b int) Unit {
-	return let _ := Choose(xs) in Unit{}
+pure func SingletonEquality(xs set[int], a int, b int) utils.Unit {
+	return let _ := Choose(xs) in utils.Unit{}
 }
 
 // Constructing new sets
@@ -190,8 +176,8 @@ requires IsSingleton(xs)
 requires e in xs
 ensures Choose(xs) == e
 decreases
-pure func ChooseFromSingleton(xs set[int], e int) Unit {
-	return Unit{}
+pure func ChooseFromSingleton(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // General definitions and properties
@@ -209,8 +195,8 @@ pure func AreDisjoint(xs, ys set[int]) bool {
 ghost
 ensures (xs == ys) == (forall e int :: {e in xs} {e in ys} ((e in xs) == (e in ys)))
 decreases
-pure func SetEquality(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SetEquality(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // Subset
@@ -222,8 +208,8 @@ requires e in xs
 requires xs subset ys
 ensures e in ys
 decreases
-pure func InSubset(xs, ys set[int], e int) Unit {
-	return Unit{}
+pure func InSubset(xs, ys set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
@@ -231,8 +217,8 @@ pure func InSubset(xs, ys set[int], e int) Unit {
 ghost
 ensures xs subset xs
 decreases
-pure func SubsetReflexive(xs set[int]) Unit {
-	return Unit{}
+pure func SubsetReflexive(xs set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
@@ -242,8 +228,8 @@ requires xs subset ys
 requires ys subset zs
 ensures xs subset zs
 decreases
-pure func SubsetTransitive(xs, ys, zs set[int]) Unit {
-	return Unit{}
+pure func SubsetTransitive(xs, ys, zs set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S1
@@ -253,8 +239,8 @@ requires xs subset ys
 requires len(xs) == len(ys)
 ensures xs == ys
 decreases
-pure func SubsetEquality(xs, ys set[int]) Unit {
-	return Asserting(len(ys setminus xs) == len(ys) - len(xs))
+pure func SubsetEquality(xs, ys set[int]) utils.Unit {
+	return utils.Asserting(len(ys setminus xs) == len(ys) - len(xs))
 }
 
 // SO
@@ -272,32 +258,32 @@ pure func IsProperSubset(xs, ys set[int]) bool {
 ghost
 ensures (e in (xs union ys)) == ((e in xs) || (e in ys))
 decreases
-pure func InUnionInOne(xs, ys set[int], e int) Unit {
-	return Unit{}
+pure func InUnionInOne(xs, ys set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // Union is commutative.
 ghost
 ensures (xs union ys) == (ys union xs)
 decreases
-pure func UnionCommutativity(xs, ys set[int]) Unit {
-	return Unit{}
+pure func UnionCommutativity(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2/S4
 ghost
 ensures (xs union ys) union ys == xs union ys
 decreases
-pure func UnionRightIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
+pure func UnionRightIdempotency(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2/S4
 ghost
 ensures xs union (xs union ys) == xs union ys
 decreases
-pure func UnionLeftIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
+pure func UnionLeftIdempotency(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // Add (union with singleton)
@@ -317,8 +303,8 @@ pure func Add(xs set[int], e int) (res set[int]) {
 ghost
 ensures (a in Add(xs, b)) == ((a == b) || a in xs)
 decreases
-pure func InAdd(xs set[int], a, b int) Unit {
-	return Unit{}
+pure func InAdd(xs set[int], a, b int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S4
@@ -326,8 +312,8 @@ ghost
 requires a in xs
 ensures a in Add(xs, b)
 decreases
-pure func InvarianceInAdd(xs set[int], a, b int) Unit {
-	return Unit{}
+pure func InvarianceInAdd(xs set[int], a, b int) utils.Unit {
+	return utils.Unit{}
 }
 
 // Remove (setminus with singleton)
@@ -347,24 +333,24 @@ pure func Remove(xs set[int], e int) set[int] {
 ghost
 ensures (xs intersection ys) == (ys intersection xs)
 decreases
-pure func IntersectionCommutativity(xs, ys set[int]) Unit {
-	return Unit{}
+pure func IntersectionCommutativity(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2
 ghost
 ensures (xs intersection ys) intersection ys == (xs intersection ys)
 decreases
-pure func IntersectionRightIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
+pure func IntersectionRightIdempotency(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2
 ghost
 ensures xs intersection (xs intersection ys) == (xs intersection ys)
 decreases
-pure func IntersectionLeftIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
+pure func IntersectionLeftIdempotency(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 
@@ -374,8 +360,8 @@ pure func IntersectionLeftIdempotency(xs, ys set[int]) Unit {
 ghost
 ensures (e in (xs setminus ys)) == ((e in xs) && !(e in ys))
 decreases
-pure func InSetminus(xs, ys set[int], e int) Unit {
-	return Unit{}
+pure func InSetminus(xs, ys set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2
@@ -384,8 +370,8 @@ ghost
 requires e in ys
 ensures !(e in (xs setminus ys))
 decreases
-pure func NotInSetminus(xs, ys set[int], e int) Unit {
-	return Unit{}
+pure func NotInSetminus(xs, ys set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // Relating multiple operations
@@ -394,8 +380,8 @@ pure func NotInSetminus(xs, ys set[int], e int) Unit {
 ghost
 ensures e in (xs intersection ys) == ((e in xs) && (e in ys))
 decreases
-pure func InIntersectionInBoth(xs, ys set[int], e int) Unit {
-	return Unit{}
+pure func InIntersectionInBoth(xs, ys set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 
@@ -405,8 +391,8 @@ requires AreDisjoint(xs, ys)
 ensures (xs union ys) setminus xs == ys
 ensures (xs union ys) setminus ys == xs
 decreases
-pure func DisjointUnionSetminus(xs, ys set[int]) Unit {
-	return Unit{}
+pure func DisjointUnionSetminus(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 
@@ -416,8 +402,8 @@ ghost
 requires e in xs
 ensures Add(Remove(xs, e), e) == xs
 decreases
-pure func AddRemove(xs set[int], e int) Unit {
-	return Unit{}
+pure func AddRemove(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
@@ -426,16 +412,16 @@ pure func AddRemove(xs set[int], e int) Unit {
 ghost
 ensures Remove(Add(xs, e), e) == Remove(xs, e)
 decreases
-pure func RemoveAdd(xs set[int], e int) Unit {
-	return Unit{}
+pure func RemoveAdd(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
 ghost
 ensures Remove(xs, e) subset xs
 decreases
-pure func SubsetRemove(xs set[int], e int) Unit {
-	return Unit{}
+pure func SubsetRemove(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // TODO Should we merge SubsetUnion1 and SubsetUnion2?
@@ -443,16 +429,16 @@ pure func SubsetRemove(xs set[int], e int) Unit {
 ghost
 ensures xs subset (xs union ys)
 decreases
-pure func SubsetUnion1(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SubsetUnion1(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
 ghost
 ensures ys subset (xs union ys)
 decreases
-pure func SubsetUnion2(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SubsetUnion2(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 
@@ -460,24 +446,24 @@ pure func SubsetUnion2(xs, ys set[int]) Unit {
 ghost
 ensures (xs intersection ys) subset xs
 decreases
-pure func SubsetIntersection1(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SubsetIntersection1(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
 ghost
 ensures (xs intersection ys) subset ys
 decreases
-pure func SubsetIntersection2(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SubsetIntersection2(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
 ghost
 ensures (xs setminus ys) subset xs 
 decreases
-pure func SubsetSetminus(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SubsetSetminus(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 
@@ -489,8 +475,8 @@ pure func SubsetSetminus(xs, ys set[int]) Unit {
 ghost
 ensures len(xs) >= 0
 decreases
-pure func NonNegativeLen(xs set[int]) Unit {
-	return Unit{}
+pure func NonNegativeLen(xs set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // TODO Get IsProperSubset case to verify
@@ -501,12 +487,12 @@ pure func NonNegativeLen(xs set[int]) Unit {
 // decreases x, y
 // ensures x subset y ==> len(x) <= len(y)
 // ensures IsProperSubset(x, y) ==> len(x) < len(y)
-// func SubsetLen(x, y set[int]) Unit {
+// func SubsetLen(x, y set[int]) utils.Unit {
 	// if len(x) != 0 {
 		// ghost e := Choose(x)
 		// SubsetLen(x setminus set[int] {e}, y setminus set[int] {e})
 	// }
-	// return Unit{}
+	// return utils.Unit{}
 // }
 
 // S1
@@ -516,14 +502,14 @@ ghost
 ensures len(xs union ys) >= len(xs)
 ensures len(xs union ys) >= len(ys)
 decreases ys
-pure func UnionLenLower(xs, ys set[int]) Unit {
-	return IsEmpty(ys) ? Unit{} :
+pure func UnionLenLower(xs, ys set[int]) utils.Unit {
+	return IsEmpty(ys) ? utils.Unit{} :
 		let y := Choose(ys) in
 		(let yr := Remove(ys, y) in
 		(y in xs ?
 			(let xr := Remove(xs, y) in
-			(let _ := Asserting(xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(let _ := Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(let _ := utils.Asserting(xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
+			(let _ := utils.Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
 }
 
 // S2
@@ -532,8 +518,8 @@ pure func UnionLenLower(xs, ys set[int]) Unit {
 ghost
 ensures len(xs union ys) <= len(xs) + len(ys)
 decreases
-pure func UnionLenUpper(xs, ys set[int]) Unit {
-	return Unit{}
+pure func UnionLenUpper(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2
@@ -542,10 +528,10 @@ pure func UnionLenUpper(xs, ys set[int]) Unit {
 ghost
 ensures len(xs intersection ys) <= len(xs)
 decreases xs
-pure func IntersectLenUpper(xs, ys set[int]) Unit {
-	return IsEmpty(xs) ? Unit{} :
+pure func IntersectLenUpper(xs, ys set[int]) utils.Unit {
+	return IsEmpty(xs) ? utils.Unit{} :
 		let x := Choose(xs) in
-		(let _ := Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(let _ := utils.Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 
@@ -554,16 +540,16 @@ pure func IntersectLenUpper(xs, ys set[int]) Unit {
 ghost
 ensures len(xs setminus ys) <= len(xs)
 decreases
-pure func SetminusLenUpper(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SetminusLenUpper(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2 (proves slightly different version)
 ghost
 ensures len(xs union ys) == len(xs) + len(ys) - len(xs intersection ys)
 decreases
-pure func UnionLenEq(xs, ys set[int]) Unit {
-	return Unit{}
+pure func UnionLenEq(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S2
@@ -571,8 +557,8 @@ ghost
 ensures len(xs setminus ys) == len(xs) - len(xs intersection ys)
 ensures len(xs setminus ys) + len(ys setminus xs) + len(xs intersection ys) == len(xs union ys)
 decreases
-pure func SetminusLenEq(xs, ys set[int]) Unit {
-	return Unit{}
+pure func SetminusLenEq(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
@@ -580,8 +566,8 @@ ghost
 ensures (e in xs) ==> (len(Add(xs, e)) == len(xs))
 ensures !(e in xs) ==> (len(Add(xs, e)) == len(xs) + 1)
 decreases
-func AddLen(xs set[int], e int) Unit {
-	return Unit{}
+func AddLen(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 // S3
@@ -589,16 +575,16 @@ ghost
 ensures (e in xs) ==> (len(Remove(xs, e)) == len(xs) - 1)
 ensures !(e in xs) ==> (len(Remove(xs, e)) == len(xs))
 decreases
-func RemoveLen(xs set[int], e int) Unit {
-	return Unit{}
+func RemoveLen(xs set[int], e int) utils.Unit {
+	return utils.Unit{}
 }
 
 ghost
 requires AreDisjoint(xs, ys)
 ensures len(xs union ys) == len(xs) + len(ys)
 decreases
-pure func DisjointUnionLen(xs, ys set[int]) Unit {
-	return Unit{}
+pure func DisjointUnionLen(xs, ys set[int]) utils.Unit {
+	return utils.Unit{}
 }
 
 // TODO If we do want this; make sure to call it something like BoundedSetLen to be consistent.

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -9,12 +9,10 @@ package sets
 // S4 https://github.com/viperproject/silicon/blob/master/src/main/resources/dafny_axioms/sets.vpr
 
 
-// TODO Go through axiomization of sets
-
 // TODO Restructure, rename and properly document definitions at the end
 // (in particular consistency in names of functions, arguments (names/order), variables)
 
-// TODO Unicode comments?
+// QUES Should we use unicode comments like ∀ x,y : set[int]. |x| ≤ |y|?
 
 // SO
 // TODO Figure out how to import these from verify.gobra
@@ -238,9 +236,9 @@ pure func SingletonSize(x set[int], e int) Unit {
 // 	return Unit{}
 // }
 
-// SKIP S1: IsSingleton (quantified predicate)
-// SKIP S1: LemmaIsSingleton (uses IsSingleton)
-// IsSingleton + LemmaIsSingleton is reduced to len(x) == 1 in our implementation.
+// SKIP S1: IsSingleton: Captured by choose and SingletonEquality
+// SKIP S1: LemmaIsSingleton: This our IsSingleton
+// -> IsSingleton + LemmaIsSingleton is reduced to len(x) == 1 in our implementation.
 // NOTE S1: ExtractFromNonEmptySet and S1: ExtractFromSingleton are in choose
 
 // SKIP S1: MapSize<> (no Injective() defined)
@@ -264,21 +262,6 @@ pure func UnionSizeLower(xs, ys set[int]) Unit {
 			(let _ := Asserting(xr union yr == Remove(xs union ys, y)) in UnionSizeLower(xr, yr))) :
 			(let _ := Asserting(xs union yr == Remove(xs union ys, y)) in UnionSizeLower(xs, yr))))
 }
-// Proof using non-pure function (TODO delete if above is okay)
-// func LemmaUnionSize(xs, ys set[int]) Unit {
-// 	if len(ys) != 0 {
-// 		ghost y := choose(ys)
-// 		ghost yr := ys setminus Singleton(y)
-// 		if y in xs {
-// 			ghost xr := xs setminus Singleton(y)
-// 			assert xr union yr == xs union ys setminus Singleton(y)
-// 			LemmaUnionSize(xr, yr)
-// 		} else {
-// 			assert xs union yr == xs union ys setminus Singleton(y)
-// 			LemmaUnionSize(xs, yr)
-// 		}
-// 	}
-// }
 
 
 // S1
@@ -303,7 +286,7 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 	return SetRange(0, n)
 }
 
-// TODO S1: LemmaBoundedSetSize (Dafny proof requires LemmaSubsetSize +
+// TODO Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
 // contains unclear forall in proof)
 
 // SKIP S1: LemmaGreatestImplies{Minimal, Maximal}, LemmaMaximalEquivalentGreatest
@@ -313,33 +296,29 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 
 // SKIP S2: is_full (don't have a notion of full)
 // SKIP S2: map<B>, fold<E> (cannot pass functions)
-// SKIP S2: to_seq() (not sure whether its fine to have forall + exists in ensures)
+// SKIP S2: to_seq() (probably not worth the quantifiers)
 // SKIP S2: to_sorted_seq() (cannot pass function)
-// SKIP S2: is_singleton() (including forall like that feels off)
+// SKIP S2: is_singleton() -> formalized above
 // SKIP S2: find_unique_{mmaximal, minimal*}() (cannot pass function)
 
-// TODO convert this into a pure function
+// TODO: Do we even want to bother with multisets?
 // S2
 // Converts a set into a multiset where each element from the set has
 // multiplicity 1 and any other element has multiplicity 0.
-ghost
-ensures forall i int :: {i # ms} (i in s) ==> ((i # ms) == 1)
-ensures forall i int :: {i # ms} (!(i in s)) ==> ((i # ms) == 0)
-decreases s
-func ToMultiset(s set[int]) (ms mset[int]) {
-	if IsEmpty(s) {
-		return mset[int] {}
-	} else {
-		ghost x := choose(s)
-		return ((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
-	}
-}
-
-// TODO Are we going to need lemmas of the form i # xmset > 0 ==> i in xmset?
+// ghost
+// ensures forall i int :: {i # ms} (i in s) ==> ((i # ms) == 1)
+// ensures forall i int :: {i # ms} (!(i in s)) ==> ((i # ms) == 0)
+// decreases s
+// pure func ToMultiset(s set[int]) (ms mset[int]) {
+// 	return IsEmpty(s) ? mset[int] {} :
+// 		let x := choose(s) in
+// 		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
+// }
 
 // SKIP: S2: lemma_len0_is_empty(self) <- this one is confusing, since we defined IsEmpty before
-// SKIP: S2: lemma_singleton_size + lemma_is_singleton (not sure whether we need 
-// these, as singleton isn't a separate notion)
+// SKIP: S2: lemma_singleton_size + lemma_is_singleton
+// => formalized empty and singleton sets above
+
 // SKIP: S2: lemma_len_filter, lemma_greatest_implies_maximal, lemma_least_implies_minimal,
 // lemma_maximal_equivalent_greatest, lemma_minimal_equivalent_least, lemma_least_is_unique,
 // lemma_greatest_is_unique, lemma_minimal_is_unique, lemma_maximal_is_unique (cannot pass functions/no ordering)
@@ -369,17 +348,6 @@ pure func IntersectSizeUpper(xs, ys set[int]) Unit {
 		(IntersectSizeUpper(Remove(xs, x), ys)))
 
 }
-// Proof using non-pure function (TODO delete if above is okay)
-// ghost
-// ensures len(xs intersection ys) <= len(xs)
-// decreases xs
-// func IntersectSizeUpper(xs, ys set[int]) Unit {
-// 	if !IsEmpty(xs) {
-// 		ghost x := choose(xs)
-// 		assert (xs setminus Singleton(x)) intersection ys == (xs intersection ys) setminus Singleton(x)
-// 		return IntersectSizeUpper(xs setminus Singleton(x), ys)
-// 	}
-// }
 
 // SKIP: S2 lemma_len_subset corresponds to SubsetSize from S1
 
@@ -397,9 +365,19 @@ pure func SetminusSizeUpper(xs, ys set[int]) Unit {
 
 // SKIP: S2: lemma_map_size (cannot pass function)
 
-// TODO Do we need lemmas to assert that union and intersect are commutative?
+ghost
+ensures (xs union ys) == (ys union xs)
+decreases
+pure func UnionCommutativity(xs, ys set[int]) Unit {
+	return Unit{}
+}
 
-// S4: union_right_idempotency -> 
+ghost
+ensures (xs intersection ys) == (ys intersection xs)
+decreases
+pure func IntersectionCommutativity(xs, ys set[int]) Unit {
+	return Unit{}
+}
 
 // S2/S4
 ghost
@@ -452,11 +430,26 @@ pure func NotInDifference(xs, ys set[int], e int) Unit {
 	return Unit{}
 }
 
-// SKIP S2: lemma_set_disjoint (no notion of disjoint in Gobra)
+// S2
+ghost
+requires AreDisjoint(xs, ys)
+ensures (xs union ys) setminus xs == ys
+ensures (xs union ys) setminus ys == xs
+decreases
+pure func SetDisjoint(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
 // SKIP S2: lemma_set_empty_equivalency_len (unclear how it ties to the rest,
 // since we already consider IsEmpty() and Choose())
 
-// SKIP S2: lemma_set_disjoint_lens (no notion of disjoint in Gobra)
+ghost
+requires AreDisjoint(xs, ys)
+ensures len(xs union ys) == len(xs) + len(ys)
+decreases
+pure func DisjointUnionSize(xs, ys set[int]) Unit {
+	return Unit{}
+}
 
 // S2 (proves slightly different version)
 ghost
@@ -488,7 +481,7 @@ pure func SetminusSize(xs, ys set[int]) Unit {
 
 // SKIP S3: mem (built-in `in`)
 // SKIP S3: (==) (built-in `==`)
-// SKIP S3: extensionality (don't seem to apply to Gobra)
+// SKIP S3: extensionality (doesn't seem to apply to Gobra)
 // SKIP S3: subset (seems to be quantified axiom)
 
 // S3
@@ -532,13 +525,8 @@ decreases
 pure func Add(xs set[int], x int) (res set[int]) {
 	return xs union SingletonSet(x)
 }
-// QUES add_def has mem y (add x s) <-> (mem y s \/ y = x) as its definition
-// We push the work to union; (how) do we need to formalize it?
 
-// SKIP S3: singleton <- already define it as literal in Singleton (S0)
-// SKIP S3: mem_singleton: contains quantifiers; unsure how to formalize singletons:
-// as set of length one? forall x, y. y in Singleton(x) => x = y (S3)?
-// forall x, y: x in Singleton(_) && y in Singleton(_) => x == y (S1, S2)?
+// SKIP S3: singleton, mem_singleton -> formalized above
 
 // S4
 ghost
@@ -566,8 +554,6 @@ decreases
 pure func Remove(xs set[int], x int) set[int] {
 	return xs setminus SingletonSet(x)
 }
-// QUES remove_def has mem y (remove x s) <-> (mem y s /\ y <> x) as its definition
-// We push the work to setminux; (how) do we need to formalize it?
 
 // S3
 // If x is in the set xs, removing and adding it back in does not change the set
@@ -599,6 +585,7 @@ pure func SubsetRemove(xs set[int], x int) Unit {
 
 // SKIP S3: union (union is already a "symbol" in Gobra)
 // SKIP S3 union_def (quantified defintion of union)
+
 // TODO Should we merge SubsetUnion1 and SubsetUnion2?
 // S3
 ghost
@@ -649,8 +636,7 @@ pure func SubsetSetminus(xs, ys set[int]) Unit {
 
 // SKIP S3: pick, pick_def (corresponds to Choose)
 // SKIP S3: disjoint, disjoint_inter_empty, disjoint_diff_eq,
-// disjoint_diff_s2: definition of disjoint requires a quantifier
-// TODO Notion of disjoint seems useful; (how) should we implement it?
+// disjoint_diff_s2: implemented above
 
 // SKIP S3 filter, filter_def, subset_filter, map, map_def, mem_map (cannot pass functions)
 
@@ -662,7 +648,6 @@ pure func CardinalNonneg(xs set[int]) Unit {
 	return Unit{}
 }
 
-// S3 SKIP: cardinal_empty: What does it mean for a set to be empty? (see above)
 
 // S3
 ghost
@@ -696,7 +681,7 @@ pure func Cardinal1(xs set[int], x int) Unit {
 }
 
 // SKIP S3 cardinal_union => corresponds to S2 UnionSizeEq
-// SKIP S3 cardinal_inter_disjoint (no notion of disjoint in gobra)
+// SKIP S3 cardinal_inter_disjoint => follows from definition of disjoint
 // SKIP S3 cardinal_diff => included in S2 SetminusSize
 // SKIP S3 cardinal_filter, cardinal_map (cannot pass functions)
 

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -3,7 +3,7 @@
   See LICENSE or go to https://github.com/viperproject/gobra-libs/blob/main/LICENSE
   for full license details.
 
-  This file is inspired by the following content:
+  This file is inspired by the standard libraries and axiomatisations of the following verifiers:
   - dafny-lang/libraries: https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
   - verus-lang/verus: https://github.com/verus-lang/verus/blob/main/source/pervasive/set_lib.rs
   - why3: https://why3.lri.fr/stdlib/set.html
@@ -17,12 +17,6 @@ package sets
 // ##(-I ../)
 import utils "utils"
 
-// QUES Do we want to have comments for every function? In some cases it is trivial, in other
-// cases it feels like the natural language version is less understandable than the formal specs.
-// TODO Improve comments
-
-// Empty set
-// *********
 // A set is empty if it has cardinality 0.
 ghost
 decreases
@@ -30,7 +24,7 @@ pure func IsEmpty(xs set[int]) bool {
 	return len(xs) == 0
 }
 
-// Returns an empty set.
+// Returns the empty set.
 ghost
 ensures IsEmpty(result)
 decreases
@@ -56,8 +50,6 @@ pure func NotInEmpty(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// Singleton set
-// **************
 // A set is a singleton if it has cardinality 1.
 ghost
 decreases
@@ -74,7 +66,7 @@ pure func SingletonSet(e int) (result set[int]) {
 	return set[int]{e}
 }
 
-// If a is in a singleton set x, then x is of the form {a}
+// If a is in a singleton set x, then x is of the form {a}.
 ghost
 requires IsSingleton(xs)
 requires e in xs
@@ -95,9 +87,7 @@ pure func SingletonEquality(xs set[int], a int, b int) utils.Unit {
 	return let _ := choose(xs) in utils.Unit{}
 }
 
-// Constructing new sets
-// **********************
-// Construct a set with all integers in the range [a, b).
+// Constructs a set with all integers in the range [a, b).
 ghost
 requires a <= b
 ensures forall i int :: { i in result } (a <= i && i < b) == i in result
@@ -107,7 +97,7 @@ pure func Range(a, b int) (result set[int]) {
 	return a == b ? EmptySet() : Add(Range(a + 1, b), a)
 }
 
-// Construct a set with all integers in the range [0, n).
+// Constructs a set with all integers in the range [0, n).
 ghost
 requires n >= 0
 ensures forall i int :: { i in result } (0 <= i && i < n) == i in result
@@ -129,9 +119,6 @@ pure func ToMultiset(s set[int]) (ms mset[int]) {
 		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
 }
 
-
-// choose axiom
-// ************
 // Returns an element from a non-empty set.
 ghost
 requires !IsEmpty(xs)
@@ -140,8 +127,6 @@ ensures IsSingleton(xs) ==> xs == SingletonSet(e)
 decreases
 pure func choose(xs set[int]) (e int)
 
-// General definitions and properties
-// **********************************
 // Returns whether xs and ys are disjoint sets.
 ghost
 decreases
@@ -157,8 +142,6 @@ pure func SetEquality(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// Subset
-// ******
 // Definition of subset without quantifiers.
 ghost
 requires e in xs
@@ -187,7 +170,7 @@ pure func SubsetIsTransitive(xs, ys, zs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// If x is a subset of y and both have the same cardinality, they are equal.
+// If xs is a subset of ys and both have the same cardinality, they are equal.
 ghost
 requires xs subset ys
 requires len(xs) == len(ys)
@@ -197,16 +180,14 @@ pure func SubsetEquality(xs, ys set[int]) utils.Unit {
 	return utils.Asserting(len(ys setminus xs) == len(ys) - len(xs))
 }
 
-// Returns whether x is a proper subset of y.
+// Returns whether xs is a proper subset of ys.
 ghost
 decreases
 pure func IsProperSubset(xs, ys set[int]) bool {
 	return xs subset ys && xs != ys
 }
 
-// Union
-// *****
-// If an e is in the union of xs and ys, then it must be in xs or ys.
+// If e is in the union of xs and ys, then it must be in xs or ys.
 ghost
 ensures (e in (xs union ys)) == ((e in xs) || (e in ys))
 decreases
@@ -222,32 +203,28 @@ pure func UnionIsCommutative(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
+// Union is idempotent.
 ghost
 ensures (xs union ys) union ys == xs union ys
-decreases
-pure func UnionIsRightIdempotent(xs, ys set[int]) utils.Unit {
-	return utils.Unit{}
-}
-
-ghost
 ensures xs union (xs union ys) == xs union ys
 decreases
-pure func UnionIsLeftIdempotent(xs, ys set[int]) utils.Unit {
+pure func UnionIsIdempotent(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// Add (union with singleton)
-// **************************
-// Add an element x to the set xs.
+// Add x to xs.
 ghost
-// Need this post-condition to verify CardinalAdd
+// Need this post-condition first to ensure the properties about the length.
 ensures (e in xs) ==> res == xs
+ensures (e in xs) ==> (len(res) == len(xs))
+ensures !(e in xs) ==> (len(res) == len(xs) + 1)
 ensures e in res
 decreases
 pure func Add(xs set[int], e int) (res set[int]) {
 	return xs union SingletonSet(e)
 }
 
+// If a is in xs union {b}, then a is equal to b, or a was already in xs.
 ghost
 ensures (a in Add(xs, b)) == ((a == b) || a in xs)
 decreases
@@ -255,6 +232,7 @@ pure func InAdd(xs set[int], a, b int) utils.Unit {
 	return utils.Unit{}
 }
 
+// If a is in xs, then a will remain in xs no matter what we add to it.
 ghost
 requires a in xs
 ensures a in Add(xs, b)
@@ -263,19 +241,17 @@ pure func InvarianceInAdd(xs set[int], a, b int) utils.Unit {
 	return utils.Unit{}
 }
 
-// Remove (setminus with singleton)
-// ********************************
-// Remove the element x from the set xs.
-// QUES Should we add something like ensures !(x in xs) ==> xs == Remove(xs, x)
-// like we did for Add?
+// Remove e from xs. Does not require e to be in xs.
 ghost
+ensures !(e in xs) ==> result == xs
+ensures (e in xs) ==> (len(result) == len(xs) - 1)
+ensures !(e in xs) ==> (len(result) == len(xs))
 decreases
-pure func Remove(xs set[int], e int) set[int] {
+pure func Remove(xs set[int], e int) (result set[int]) {
 	return xs setminus SingletonSet(e)
 }
 
-// Intersection
-// ************
+// Intersection is commutative.
 ghost
 ensures (xs intersection ys) == (ys intersection xs)
 decreases
@@ -283,23 +259,16 @@ pure func IntersectionIsCommutative(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
+// Intersection is idempotent.
 ghost
 ensures (xs intersection ys) intersection ys == (xs intersection ys)
-decreases
-pure func IntersectionIsRightIdempotent(xs, ys set[int]) utils.Unit {
-	return utils.Unit{}
-}
-
-ghost
 ensures xs intersection (xs intersection ys) == (xs intersection ys)
 decreases
-pure func IntersectionIsLeftIdempotent(xs, ys set[int]) utils.Unit {
+pure func IntersectionIsIdempotent(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-
-// Setminus
-// ********
+// If e is in the difference xs - ys, then e must be in xs but not in ys.
 ghost
 ensures (e in (xs setminus ys)) == ((e in xs) && !(e in ys))
 decreases
@@ -316,8 +285,7 @@ pure func NotInDifference(xs, ys set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// Relating multiple operations
-// ****************************
+// If e is in the intersection of xs and ys, then e must be both in xs and ys.
 ghost
 ensures e in (xs intersection ys) == ((e in xs) && (e in ys))
 decreases
@@ -325,6 +293,8 @@ pure func InIntersectionInBoth(xs, ys set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
+// If xs and ys are disjoint, adding and then removing one from the other
+// yields the original set.
 ghost
 requires AreDisjoint(xs, ys)
 ensures (xs union ys) setminus xs == ys
@@ -343,7 +313,7 @@ pure func AddRemove(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// If we remove x from the set xs, it doesn't matter whether we have added x
+// If we remove e from the set xs, it doesn't matter whether we have added e
 // to it before.
 ghost
 ensures Remove(Add(xs, e), e) == Remove(xs, e)
@@ -352,6 +322,7 @@ pure func RemoveAdd(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
+// xs - {e} is a subset of xs.
 ghost
 ensures Remove(xs, e) subset xs
 decreases
@@ -359,35 +330,25 @@ pure func SubsetRemove(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// QUES Should we merge SubsetUnion1 and SubsetUnion2?
+// xs and ys are subsets of the union of xs and ys.
 ghost
 ensures xs subset (xs union ys)
-decreases
-pure func SubsetUnion1(xs, ys set[int]) utils.Unit {
-	return utils.Unit{}
-}
-
-ghost
 ensures ys subset (xs union ys)
 decreases
-pure func SubsetUnion2(xs, ys set[int]) utils.Unit {
+pure func SubsetUnion(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
+// The intersection of xs and ys are subsets of xs, and ys.
 ghost
 ensures (xs intersection ys) subset xs
-decreases
-pure func SubsetIntersection1(xs, ys set[int]) utils.Unit {
-	return utils.Unit{}
-}
-
-ghost
 ensures (xs intersection ys) subset ys
 decreases
-pure func SubsetIntersection2(xs, ys set[int]) utils.Unit {
+pure func SubsetIntersection(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
+// The difference xs - ys is a subset of xs.
 ghost
 ensures (xs setminus ys) subset xs 
 decreases
@@ -395,9 +356,6 @@ pure func SubsetDifference(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-
-// Cardinality
-// ***********
 // The cardinality of a set is non-negative.
 ghost
 ensures len(xs) >= 0
@@ -481,6 +439,8 @@ pure func DifferenceLenEq(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
+// If e is in xs, adding it to xs doesn't change the cardinality.
+// If e is not in xs, adding it to xs increases the cardinality by 1.
 ghost
 ensures (e in xs) ==> (len(Add(xs, e)) == len(xs))
 ensures !(e in xs) ==> (len(Add(xs, e)) == len(xs) + 1)
@@ -489,6 +449,8 @@ func AddLen(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
+// If e is in xs, removing it from xs reduces the cardinality by 1.
+// If e is not in xs, removing it from xs doesn't change the cardinality.
 ghost
 ensures (e in xs) ==> (len(Remove(xs, e)) == len(xs) - 1)
 ensures !(e in xs) ==> (len(Remove(xs, e)) == len(xs))
@@ -497,6 +459,8 @@ func RemoveLen(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
+// If xs and ys are disjoint, the cardinality of their union is equal to the
+// sum of the cardinality of xs, and the cardinality of ys.
 ghost
 requires AreDisjoint(xs, ys)
 ensures len(xs union ys) == len(xs) + len(ys)
@@ -514,16 +478,5 @@ pure func DisjointUnionLen(xs, ys set[int]) utils.Unit {
 //     requires a <= b
 //     ensures |x| <= b - a
 
-// *****************
-
 // QUES S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
 // their post-condition; do we want these functions?
-
-
-// S3 The sections in "Finite Monomorphic sets" suggest to move cardinality properties as a
-// postcondition to functions that "generate" it
-// Empty() would return an empty list, but also ensure that its cardinality is 0
-// Add(xs, x) would return a set where x has been added to xs, but also ensure that
-// the cardinality stays the same if x was already in xs, or increases if it wasnt
-// A similar consideration is made for Singleton(x) and Remove(xs, x)
-// QUES Do we want to merge functions like this?

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -1,61 +1,53 @@
+/*
+  This file is part of gobra-libs which is released under the MIT license.
+  See LICENSE or go to https://github.com/viperproject/gobra-libs/blob/main/LICENSE
+  for full license details.
+
+  This file is inspired by the following content:
+  - dafny-lang/libraries: https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
+  - verus-lang/verus: https://github.com/verus-lang/verus/blob/main/source/pervasive/set_lib.rs
+  - why3: https://why3.lri.fr/stdlib/set.html
+  - viperproject/silicon: https://github.com/viperproject/silicon/blob/master/src/main/resources/dafny_axioms/sets.vpr
+
+*/
+
 // This package defines lemmas for sets commonly used in specifications.
 package sets
 
 // ##(-I ../)
 import utils "utils"
 
-// TODO Add proper attribution
-// SO Not taken from outside sources
-// S1 https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
-// S2 https://github.com/verus-lang/verus/blob/main/source/pervasive/set_lib.rs
-// S3 https://why3.lri.fr/stdlib/set.html
-// S4 https://github.com/viperproject/silicon/blob/master/src/main/resources/dafny_axioms/sets.vpr
-
-
+// QUES Do we want to have comments for every function? In some cases it is trivial, in other
+// cases it feels like the natural language version is less understandable than the formal specs.
 // TODO Improve comments
-// QUES Should we use unicode comments like ∀ x,y : set[int]. |x| ≤ |y|?
-
 
 // Empty set
 // *********
-// S2
-// A set is empty if it has length 0.
+// A set is empty if it has cardinality 0.
 ghost
 decreases
 pure func IsEmpty(xs set[int]) bool {
 	return len(xs) == 0
 }
 
-// S0
-// Returns an empty set {}.
+// Returns an empty set.
 ghost
 ensures IsEmpty(result)
 decreases
 pure func EmptySet() (result set[int]) {
-	return set[int] {}
+	return set[int]{}
 }
 
-// An empty set has length 0.
-ghost
-requires xs == EmptySet()
-ensures IsEmpty(xs)
-decreases
-pure func EmptyLen(xs set[int]) utils.Unit {
-	return utils.Unit{}
-}
-
-// S3
-// A set of length 0 is the empty set.
+// There is only one empty set.
 ghost
 requires IsEmpty(xs)
 ensures xs == EmptySet()
 decreases
-pure func EmptyIsEmptySet(xs set[int]) utils.Unit {
+pure func EmptySetIsUnique(xs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3, S4
-// Nothing can be an element of the empty set.
+// An empty set doesn't have any elements.
 ghost
 requires IsEmpty(xs)
 ensures !(e in xs)
@@ -66,35 +58,22 @@ pure func NotInEmpty(xs set[int], e int) utils.Unit {
 
 // Singleton set
 // **************
-// S1
-// A set is a singleton if it has length 1.
+// A set is a singleton if it has cardinality 1.
 ghost
 decreases
 pure func IsSingleton(xs set[int]) bool {
 	return len(xs) == 1
 }
 
-// SO
-// Returns a singleton set containing x.
+// Returns a singleton containing x.
 ghost
 ensures IsSingleton(result)
 ensures e in result
 decreases
 pure func SingletonSet(e int) (result set[int]) {
-	return set[int] {e}
+	return set[int]{e}
 }
 
-// S1
-// A singleton set has a length of 1.
-ghost
-requires xs == SingletonSet(e)
-ensures IsSingleton(xs)
-decreases
-pure func SingletonLen(xs set[int], e int) utils.Unit {
-	return utils.Unit{}
-}
-
-// S0
 // If a is in a singleton set x, then x is of the form {a}
 ghost
 requires IsSingleton(xs)
@@ -102,10 +81,9 @@ requires e in xs
 ensures xs == SingletonSet(e)
 decreases
 pure func SingletonIsSingletonSet(xs set[int], e int) utils.Unit {
-	return let _ := Choose(xs) in utils.Unit{}
+	return let _ := choose(xs) in utils.Unit{}
 }
 
-// S1
 // Elements in a singleton set are equal to each other.
 ghost
 requires IsSingleton(xs)
@@ -114,13 +92,11 @@ requires b in xs
 ensures a == b
 decreases
 pure func SingletonEquality(xs set[int], a int, b int) utils.Unit {
-	return let _ := Choose(xs) in utils.Unit{}
+	return let _ := choose(xs) in utils.Unit{}
 }
 
 // Constructing new sets
 // **********************
-
-// S1
 // Construct a set with all integers in the range [a, b).
 ghost
 requires a <= b
@@ -131,7 +107,6 @@ pure func Range(a, b int) (result set[int]) {
 	return a == b ? EmptySet() : Add(Range(a + 1, b), a)
 }
 
-// S1
 // Construct a set with all integers in the range [0, n).
 ghost
 requires n >= 0
@@ -142,47 +117,31 @@ pure func RangeFromZero(n int) (result set[int]) {
 	return Range(0, n)
 }
 
-// TODO: Do we want to implement multisets?
-// S2
 // Converts a set into a multiset where each element from the set has
 // multiplicity 1 and any other element has multiplicity 0.
-// ghost
-// ensures forall i int :: {i # ms} (i in s) ==> ((i # ms) == 1)
-// ensures forall i int :: {i # ms} (!(i in s)) ==> ((i # ms) == 0)
-// decreases s
-// pure func ToMultiset(s set[int]) (ms mset[int]) {
-// 	return IsEmpty(s) ? mset[int] {} :
-// 		let x := Choose(s) in
-// 		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
-// }
+ghost
+ensures forall i int :: {i # ms} (i in s) ==> ((i # ms) == 1)
+ensures forall i int :: {i # ms} (!(i in s)) ==> ((i # ms) == 0)
+decreases s
+pure func ToMultiset(s set[int]) (ms mset[int]) {
+	return IsEmpty(s) ? mset[int] {} :
+		let x := choose(s) in
+		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
+}
 
 
 // choose axiom
 // ************
-// S0/S1
 // Returns an element from a non-empty set.
 ghost
 requires !IsEmpty(xs)
 ensures e in xs
 ensures IsSingleton(xs) ==> xs == SingletonSet(e)
 decreases
-pure func Choose(xs set[int]) (e int)
-
-// TODO Is this needed? It feels similar to what we get from calling Choose
-// S3
-// If xs is a Singleton, and x is in xs, then Choose(xs) will always return x.
-ghost
-requires IsSingleton(xs)
-requires e in xs
-ensures Choose(xs) == e
-decreases
-pure func ChooseFromSingleton(xs set[int], e int) utils.Unit {
-	return utils.Unit{}
-}
+pure func choose(xs set[int]) (e int)
 
 // General definitions and properties
 // **********************************
-// S4
 // Returns whether xs and ys are disjoint sets.
 ghost
 decreases
@@ -190,7 +149,6 @@ pure func AreDisjoint(xs, ys set[int]) bool {
 	return IsEmpty(xs intersection ys)
 }
 
-// S4
 // Definition of set equality.
 ghost
 ensures (xs == ys) == (forall e int :: {e in xs} {e in ys} ((e in xs) == (e in ys)))
@@ -201,7 +159,6 @@ pure func SetEquality(xs, ys set[int]) utils.Unit {
 
 // Subset
 // ******
-// S3
 // Definition of subset without quantifiers.
 ghost
 requires e in xs
@@ -212,28 +169,25 @@ pure func InSubset(xs, ys set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 // Subset relation is reflexive.
 ghost
 ensures xs subset xs
 decreases
-pure func SubsetReflexive(xs set[int]) utils.Unit {
+pure func SubsetIsReflexive(xs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 // Subset relation is transitive.
 ghost
 requires xs subset ys
 requires ys subset zs
 ensures xs subset zs
 decreases
-pure func SubsetTransitive(xs, ys, zs set[int]) utils.Unit {
+pure func SubsetIsTransitive(xs, ys, zs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S1
-// If x is a subset of y and both have the same length, they are equal.
+// If x is a subset of y and both have the same cardinality, they are equal.
 ghost
 requires xs subset ys
 requires len(xs) == len(ys)
@@ -243,7 +197,6 @@ pure func SubsetEquality(xs, ys set[int]) utils.Unit {
 	return utils.Asserting(len(ys setminus xs) == len(ys) - len(xs))
 }
 
-// SO
 // Returns whether x is a proper subset of y.
 ghost
 decreases
@@ -253,7 +206,6 @@ pure func IsProperSubset(xs, ys set[int]) bool {
 
 // Union
 // *****
-// S4
 // If an e is in the union of xs and ys, then it must be in xs or ys.
 ghost
 ensures (e in (xs union ys)) == ((e in xs) || (e in ys))
@@ -266,29 +218,26 @@ pure func InUnionInOne(xs, ys set[int], e int) utils.Unit {
 ghost
 ensures (xs union ys) == (ys union xs)
 decreases
-pure func UnionCommutativity(xs, ys set[int]) utils.Unit {
+pure func UnionIsCommutative(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2/S4
 ghost
 ensures (xs union ys) union ys == xs union ys
 decreases
-pure func UnionRightIdempotency(xs, ys set[int]) utils.Unit {
+pure func UnionIsRightIdempotent(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2/S4
 ghost
 ensures xs union (xs union ys) == xs union ys
 decreases
-pure func UnionLeftIdempotency(xs, ys set[int]) utils.Unit {
+pure func UnionIsLeftIdempotent(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
 // Add (union with singleton)
 // **************************
-// S3 (add, add_def)
 // Add an element x to the set xs.
 ghost
 // Need this post-condition to verify CardinalAdd
@@ -299,7 +248,6 @@ pure func Add(xs set[int], e int) (res set[int]) {
 	return xs union SingletonSet(e)
 }
 
-// S4
 ghost
 ensures (a in Add(xs, b)) == ((a == b) || a in xs)
 decreases
@@ -307,7 +255,6 @@ pure func InAdd(xs set[int], a, b int) utils.Unit {
 	return utils.Unit{}
 }
 
-// S4
 ghost
 requires a in xs
 ensures a in Add(xs, b)
@@ -318,9 +265,8 @@ pure func InvarianceInAdd(xs set[int], a, b int) utils.Unit {
 
 // Remove (setminus with singleton)
 // ********************************
-// S3
 // Remove the element x from the set xs.
-// TODO Should we add something like ensures !(x in xs) ==> xs == Remove(xs, x)
+// QUES Should we add something like ensures !(x in xs) ==> xs == Remove(xs, x)
 // like we did for Add?
 ghost
 decreases
@@ -333,50 +279,45 @@ pure func Remove(xs set[int], e int) set[int] {
 ghost
 ensures (xs intersection ys) == (ys intersection xs)
 decreases
-pure func IntersectionCommutativity(xs, ys set[int]) utils.Unit {
+pure func IntersectionIsCommutative(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2
 ghost
 ensures (xs intersection ys) intersection ys == (xs intersection ys)
 decreases
-pure func IntersectionRightIdempotency(xs, ys set[int]) utils.Unit {
+pure func IntersectionIsRightIdempotent(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2
 ghost
 ensures xs intersection (xs intersection ys) == (xs intersection ys)
 decreases
-pure func IntersectionLeftIdempotency(xs, ys set[int]) utils.Unit {
+pure func IntersectionIsLeftIdempotent(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
 
 // Setminus
 // ********
-// S4
 ghost
 ensures (e in (xs setminus ys)) == ((e in xs) && !(e in ys))
 decreases
-pure func InSetminus(xs, ys set[int], e int) utils.Unit {
+pure func InDifference(xs, ys set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2
 // If ys contains e, then the difference xs - ys does not contain e.
 ghost
 requires e in ys
 ensures !(e in (xs setminus ys))
 decreases
-pure func NotInSetminus(xs, ys set[int], e int) utils.Unit {
+pure func NotInDifference(xs, ys set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
 // Relating multiple operations
 // ****************************
-// S4
 ghost
 ensures e in (xs intersection ys) == ((e in xs) && (e in ys))
 decreases
@@ -384,20 +325,16 @@ pure func InIntersectionInBoth(xs, ys set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-
-// S2
 ghost
 requires AreDisjoint(xs, ys)
 ensures (xs union ys) setminus xs == ys
 ensures (xs union ys) setminus ys == xs
 decreases
-pure func DisjointUnionSetminus(xs, ys set[int]) utils.Unit {
+pure func DisjointUnionDifference(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-
-// S3
-// If x is in the set xs, removing and adding it back in does not change the set
+// If e is in xs, removing and adding it back yields the original set.
 ghost
 requires e in xs
 ensures Add(Remove(xs, e), e) == xs
@@ -406,7 +343,6 @@ pure func AddRemove(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 // If we remove x from the set xs, it doesn't matter whether we have added x
 // to it before.
 ghost
@@ -416,7 +352,6 @@ pure func RemoveAdd(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 ghost
 ensures Remove(xs, e) subset xs
 decreases
@@ -424,8 +359,7 @@ pure func SubsetRemove(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// TODO Should we merge SubsetUnion1 and SubsetUnion2?
-// S3
+// QUES Should we merge SubsetUnion1 and SubsetUnion2?
 ghost
 ensures xs subset (xs union ys)
 decreases
@@ -433,7 +367,6 @@ pure func SubsetUnion1(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 ghost
 ensures ys subset (xs union ys)
 decreases
@@ -441,8 +374,6 @@ pure func SubsetUnion2(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-
-// S3
 ghost
 ensures (xs intersection ys) subset xs
 decreases
@@ -450,7 +381,6 @@ pure func SubsetIntersection1(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 ghost
 ensures (xs intersection ys) subset ys
 decreases
@@ -458,20 +388,17 @@ pure func SubsetIntersection2(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 ghost
 ensures (xs setminus ys) subset xs 
 decreases
-pure func SubsetSetminus(xs, ys set[int]) utils.Unit {
+pure func SubsetDifference(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
 
-// Length
-// ******
-
-// S4
-// The length of a set is non-negative.
+// Cardinality
+// ***********
+// The cardinality of a set is non-negative.
 ghost
 ensures len(xs) >= 0
 decreases
@@ -479,24 +406,22 @@ pure func NonNegativeLen(xs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// TODO Get IsProperSubset case to verify
-// S1
-// If x is a subset of y, then the length of x is less than or equal to the length of y.
-// If x is a strict subset of y, then the length of x is less than to the length of y.
+// QUES I cannot get the IsProperSubset case to verify; Verus doesn't include this case either. Do we skip it for now?
+// If x is a subset of y, then the cardinality of x is less than or equal to the cardinality of y.
+// {If x is a strict subset of y, then the cardinality of x is less than to the cardinality of y.}
 // ghost
 // decreases x, y
 // ensures x subset y ==> len(x) <= len(y)
 // ensures IsProperSubset(x, y) ==> len(x) < len(y)
 // func SubsetLen(x, y set[int]) utils.Unit {
-	// if len(x) != 0 {
-		// ghost e := Choose(x)
-		// SubsetLen(x setminus set[int] {e}, y setminus set[int] {e})
-	// }
-	// return utils.Unit{}
+// 	if len(x) != 0 {
+// 		ghost e := choose(x)
+// 		SubsetLen(x setminus set[int] {e}, y setminus set[int] {e})
+// 	}
+// 	return utils.Unit{}
 // }
 
-// S1
-// The length of a union of two sets is greater than or equal to the length of
+// The cardinality of a union of two sets is greater than or equal to the cardinality of
 // either individual set.
 ghost
 ensures len(xs union ys) >= len(xs)
@@ -504,7 +429,7 @@ ensures len(xs union ys) >= len(ys)
 decreases ys
 pure func UnionLenLower(xs, ys set[int]) utils.Unit {
 	return IsEmpty(ys) ? utils.Unit{} :
-		let y := Choose(ys) in
+		let y := choose(ys) in
 		(let yr := Remove(ys, y) in
 		(y in xs ?
 			(let xr := Remove(xs, y) in
@@ -512,8 +437,7 @@ pure func UnionLenLower(xs, ys set[int]) utils.Unit {
 			(let _ := utils.Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
 }
 
-// S2
-// The length of a union of two sets is less than or equal to the length of
+// The cardinality of a union of two sets is less than or equal to the cardinality of
 // both individual sets combined.
 ghost
 ensures len(xs union ys) <= len(xs) + len(ys)
@@ -522,29 +446,26 @@ pure func UnionLenUpper(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2
-// The length of the intersection of xs and ys is less than or equal to the
-// length of xs.
+// The cardinality of the intersection of xs and ys is less than or equal to the
+// cardinality of xs.
 ghost
 ensures len(xs intersection ys) <= len(xs)
 decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) utils.Unit {
 	return IsEmpty(xs) ? utils.Unit{} :
-		let x := Choose(xs) in
+		let x := choose(xs) in
 		(let _ := utils.Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 
-// S2
-// The length of the difference xs - ys is less than or equal to the length of xs. 
+// The cardinality of the difference xs - ys is less than or equal to the cardinality of xs. 
 ghost
 ensures len(xs setminus ys) <= len(xs)
 decreases
-pure func SetminusLenUpper(xs, ys set[int]) utils.Unit {
+pure func DifferenceLenUpper(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2 (proves slightly different version)
 ghost
 ensures len(xs union ys) == len(xs) + len(ys) - len(xs intersection ys)
 decreases
@@ -552,16 +473,14 @@ pure func UnionLenEq(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S2
 ghost
 ensures len(xs setminus ys) == len(xs) - len(xs intersection ys)
 ensures len(xs setminus ys) + len(ys setminus xs) + len(xs intersection ys) == len(xs union ys)
 decreases
-pure func SetminusLenEq(xs, ys set[int]) utils.Unit {
+pure func DifferenceLenEq(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 ghost
 ensures (e in xs) ==> (len(Add(xs, e)) == len(xs))
 ensures !(e in xs) ==> (len(Add(xs, e)) == len(xs) + 1)
@@ -570,7 +489,6 @@ func AddLen(xs set[int], e int) utils.Unit {
 	return utils.Unit{}
 }
 
-// S3
 ghost
 ensures (e in xs) ==> (len(Remove(xs, e)) == len(xs) - 1)
 ensures !(e in xs) ==> (len(Remove(xs, e)) == len(xs))
@@ -587,9 +505,9 @@ pure func DisjointUnionLen(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// TODO If we do want this; make sure to call it something like BoundedSetLen to be consistent.
-// TODO Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
+// QUES Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
 // contains unclear forall in proof)
+// TODO If we do want this; make sure to call it something like BoundedSetLen to be consistent.
 // Dafny signature:
 //   lemma LemmaBoundedSetSize(x: set<int>, a: int, b: int)
 //     requires forall i {:trigger i in x} :: i in x ==> a <= i < b
@@ -598,7 +516,7 @@ pure func DisjointUnionLen(xs, ys set[int]) utils.Unit {
 
 // *****************
 
-// TODO S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
+// QUES S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
 // their post-condition; do we want these functions?
 
 
@@ -608,4 +526,4 @@ pure func DisjointUnionLen(xs, ys set[int]) utils.Unit {
 // Add(xs, x) would return a set where x has been added to xs, but also ensure that
 // the cardinality stays the same if x was already in xs, or increases if it wasnt
 // A similar consideration is made for Singleton(x) and Remove(xs, x)
-// TODO Do we want to merge functions like this?
+// QUES Do we want to merge functions like this?

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -601,6 +601,7 @@ pure func DisjointUnionLen(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
+// TODO If we do want this; make sure to call it something like BoundedSetLen to be consistent.
 // TODO Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
 // contains unclear forall in proof)
 // Dafny signature:

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -8,14 +8,11 @@ package sets
 // S3 https://why3.lri.fr/stdlib/set.html
 
 
-// (How) Should we transform the axiomization of sets into lemmas?
+// TODO Go through axiomization of sets
 
 // TODO Restructure, rename and properly document definitions at the end
-// (in particular consistency in names of functions, arguments, variables)
+// (in particular consistency in names of functions, arguments (names/order), variables)
 
-// QUES How will set literals be interpreted if we turn of the axioms?
-
-// TODO Figure out what the Gobra warnings are
 // TODO Unicode comments?
 
 // SO
@@ -34,7 +31,7 @@ ensures false
 decreases _
 func TODO()
 
-// SKIP S1: LemmaSubset<T>, quantified definition of subset
+// SKIP S1: LemmaSubset<T>; implemented below as Subset from S3
 
 // SO
 // Returns whether x is a proper subset of y.
@@ -44,27 +41,45 @@ pure func IsProperSubset(x, y set[int]) bool {
 	return x subset y && x != y
 }
 
+// S1
+ghost
+decreases
+pure func IsSingleton(x set[int]) bool {
+	return len(x) == 1
+}
+
 // SO
 // Returns a singleton set containing x.
 ghost
+ensures IsSingleton(result)
 decreases
-pure func Singleton(x int) set[int] {
+pure func SingletonSet(x int) (result set[int]) {
 	return set[int] {x}
 }
 
-// TODO Figure out how to properly formalize empty (see comment about
-// empty from S3 below)
-
-// TODO Figure out how to properly formalize Singleton; probably requires
-// similar considerations as empty
+// S1
+// Elements in a singleton set are equal to each other
+// TODO Prove this: Dafny proof requires strict case of SubsetSize
+// ghost
+// requires IsSingleton(x)
+// requires a in x
+// requires b in x
+// ensures a == b
+// decreases
+// pure func SingletonEquality(x set[int], a int, b int) Unit {
+// 	return Unit{}
+// }
 
 // S0
-// Returns an empty set.
-ghost
-decreases
-pure func Empty() set[int] {
-	return set[int] {}
-}
+// If a is in a singleton set x, then x is of the form {a}
+// TODO Prove this
+// ghost
+// requires IsSingleton(x)
+// requires a in x
+// ensures x == SingletonSet(a)
+// pure func SingletonIsSingletonSet(x set[int], a int) Unit {
+// 	return Unit{}
+// }
 
 // S2
 // Returns whether x is empty.
@@ -74,12 +89,41 @@ pure func IsEmpty(x set[int]) bool {
 	return len(x) == 0
 }
 
+// S0
+// Returns an empty set.
+ghost
+ensures IsEmpty(result)
+decreases
+pure func EmptySet() (result set[int]) {
+	return set[int] {}
+}
+
+// S3
+// Nothing can be an element of the empty set.
+ghost
+requires IsEmpty(x)
+ensures !(e in x)
+decreases
+pure func ElementNotInEmpty(x set[int], e int) Unit {
+	return Unit{}
+}
+
+// S3
+// A set of length 0 is the empty set.
+ghost
+requires IsEmpty(x)
+ensures x == EmptySet()
+decreases
+pure func EmptyIsEmptySet(x set[int]) Unit {
+	return Unit{}
+}
+
 // S0/S1
 // Returns an element from a non-empty set.
 ghost
 requires !IsEmpty(xs)
 ensures x in xs
-ensures len(xs) == 1 ==> xs == Singleton(x)
+ensures len(xs) == 1 ==> xs == SingletonSet(x)
 decreases
 pure func choose(xs set[int]) (x int)
 
@@ -113,7 +157,7 @@ pure func SubsetEquality(x, y set[int]) Unit {
 // S1
 // A singleton set has a size of 1.
 ghost
-requires x == Singleton(e)
+requires x == SingletonSet(e)
 ensures len(x) == 1
 decreases
 pure func SingletonSize(x set[int], e int) Unit {
@@ -135,6 +179,7 @@ pure func SingletonSize(x set[int], e int) Unit {
 
 // SKIP S1: IsSingleton (quantified predicate)
 // SKIP S1: LemmaIsSingleton (uses IsSingleton)
+// IsSingleton + LemmaIsSingleton is reduced to len(x) == 1 in our implementation.
 // NOTE S1: ExtractFromNonEmptySet and S1: ExtractFromSingleton are in choose
 
 // SKIP S1: MapSize<> (no Injective() defined)
@@ -183,7 +228,7 @@ ensures forall i int :: { i in s } (a <= i && i < b) == i in s
 ensures len(s) == b - a
 decreases b - a
 pure func SetRange(a, b int) (s set[int]) {
-	return a == b ? Empty() : Add(SetRange(a + 1, b), a)
+	return a == b ? EmptySet() : Add(SetRange(a + 1, b), a)
 }
 
 // S1
@@ -404,13 +449,6 @@ pure func SubsetTransitive(xs, ys, zs set[int]) Unit {
 	return Unit{}
 }
 
-// SKIP: S3 is_empty, empty, is_empty_empty, empty_is_empty
-// unsure how to formalize the empty set: Is it defined as {}, a set of len 0,
-// or as a set s such that forall e . e not in s?
-
-
-// TODO Can we write functions like Add, Remove, etc. (and some above) as Go
-// methods?
 // S3 (add, add_def)
 // Add an element x to the set xs.
 ghost
@@ -418,7 +456,7 @@ ghost
 ensures (x in xs) ==> res == xs
 decreases
 pure func Add(xs set[int], x int) (res set[int]) {
-	return xs union Singleton(x)
+	return xs union SingletonSet(x)
 }
 // QUES add_def has mem y (add x s) <-> (mem y s \/ y = x) as its definition
 // We push the work to union; (how) do we need to formalize it?
@@ -435,7 +473,7 @@ pure func Add(xs set[int], x int) (res set[int]) {
 ghost
 decreases
 pure func Remove(xs set[int], x int) set[int] {
-	return xs setminus Singleton(x)
+	return xs setminus SingletonSet(x)
 }
 // QUES remove_def has mem y (remove x s) <-> (mem y s /\ y <> x) as its definition
 // We push the work to setminux; (how) do we need to formalize it?

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -4,6 +4,10 @@ package sets
 // TODO Add proper attribution
 // SO Not taken from outside sources
 // S1 https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
+// S2 https://github.com/verus-lang/verus/blob/main/source/pervasive/set_lib.rs
+
+// TODO Restructure, rename and properly document definitions at the end
+// (in particular consistency in names of functions, arguments, variables)
 
 // SO
 // TODO Figure out how to import these from verify.gobra
@@ -15,6 +19,11 @@ decreases
 pure func Asserting(ghost b bool) Unit {
 	return Unit{}
 }
+
+ghost
+ensures false
+decreases _
+func TODO()
 
 // SKIP S1: LemmaSubset<T>, quantified definition of subset
 
@@ -42,13 +51,21 @@ pure func Empty() set[int] {
 	return set[int] {}
 }
 
+// S2
+// Returns whether x is empty.
+ghost
+decreases
+pure func IsEmpty(x set[int]) bool {
+	return len(x) == 0
+}
+
 // S0/S1
 // Returns an element from a non-empty set.
 ghost
-decreases
-requires len(xs) != 0
+requires !IsEmpty(xs)
 ensures x in xs
 ensures len(xs) == 1 ==> xs == Singleton(x)
+decreases
 pure func choose(xs set[int]) (x int)
 
 // TODO Get IsProperSubset case to verify
@@ -117,14 +134,14 @@ ghost
 ensures len(xs union ys) >= len(xs)
 ensures len(xs union ys) >= len(ys)
 decreases ys
-pure func LemmaUnionSize(xs, ys set[int]) Unit {
-	return len(ys) == 0 ? Unit{} :
+pure func UnionSizeLower(xs, ys set[int]) Unit {
+	return IsEmpty(ys) ? Unit{} :
 		let y := choose(ys) in
 		(let yr := ys setminus Singleton(y) in
 		(y in xs ?
 			(let xr := xs setminus Singleton(y) in
-			(let _ := Asserting(xr union yr == xs union ys setminus Singleton(y)) in LemmaUnionSize(xr, yr))) :
-			(let _ := Asserting(xs union yr == xs union ys setminus Singleton(y)) in LemmaUnionSize(xs, yr))))
+			(let _ := Asserting(xr union yr == xs union ys setminus Singleton(y)) in UnionSizeLower(xr, yr))) :
+			(let _ := Asserting(xs union yr == xs union ys setminus Singleton(y)) in UnionSizeLower(xs, yr))))
 }
 // Proof using non-pure function (TODO delete if above is okay)
 // func LemmaUnionSize(xs, ys set[int]) Unit {
@@ -160,6 +177,7 @@ ghost
 requires n >= 0
 ensures forall i int :: {i in s} (0 <= i && i < n) == i in s
 ensures len(s) == n
+decreases
 pure func SetRangeFromZero(n int) (s set[int]) {
 	return SetRange(0, n)
 }
@@ -171,3 +189,158 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 // LemmaMinimalEquivalentLeast, LeammLeastIsUnique, LemmaGreatestIsUnique, LemmaMinimalIsUnique
 // LemmaMaximalIsUnique, LemmaFindUniqueMinimal, LemmaFindUniqueMaximal
 // since Orderings are not defined
+
+// SKIP S2: is_full (don't have a notion of full)
+// SKIP S2: map<B>, fold<E> (cannot pass functions)
+// SKIP S2: to_seq() (not sure whether its fine to have forall + exists in ensures)
+// SKIP S2: to_sorted_seq() (cannot pass function)
+// SKIP S2: is_singleton() (including forall like that feels off)
+// SKIP S2: find_unique_{mmaximal, minimal*}() (cannot pass function)
+
+// S2
+// Converts a set into a multiset where each element from the set has
+// multiplicity 1 and any other element has multiplicity 0.
+ghost
+ensures forall i int :: {i # ms} (i in s) ==> ((i # ms) == 1)
+ensures forall i int :: {i # ms} (!(i in s)) ==> ((i # ms) == 0)
+decreases s
+func ToMultiset(s set[int]) (ms mset[int]) {
+	if IsEmpty(s) {
+		return mset[int] {}
+	} else {
+		ghost x := choose(s)
+		return ((mset[int] {}) union (mset[int] {x})) union ToMultiset(s setminus Singleton(x))
+	}
+}
+
+// TODO Are we going to need lemmas of the form i # xmset > 0 ==> i in xmset?
+
+// SKIP: S2: lemma_len0_is_empty(self) <- this one is confusing, since we defined IsEmpty before
+// SKIP: S2: lemma_singleton_size + lemma_is_singleton (not sure whether we need 
+// these, as singleton isn't a separate notion)
+// SKIP: S2: lemma_len_filter, lemma_greatest_implies_maximal, lemma_least_implies_minimal,
+// lemma_maximal_equivalent_greatest, lemma_minimal_equivalent_least, lemma_least_is_unique,
+// lemma_greatest_is_unique, lemma_minimal_is_unique, lemma_maximal_is_unique (cannot pass functions/no ordering)
+
+// S2
+// The size of a union of two sets is less than or equal to the size of
+// both individual sets combined.
+ghost
+ensures len(xs union ys) <= len(xs) + len(ys)
+decreases
+pure func UnionSizeUpper(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// SKIP: S2: lemma_len_union_ind (corresponds to UnionSizeLower from S1)
+
+// S2
+// The size of the intersection of xs and ys is less than or equal to the
+// size of xs.
+ghost
+ensures len(xs intersection ys) <= len(xs)
+decreases xs
+pure func IntersectSizeUpper(xs, ys set[int]) Unit {
+	return IsEmpty(xs) ? Unit{} :
+		let x := Singleton(choose(xs)) in
+		(let _ := Asserting((xs setminus x) intersection ys == (xs intersection ys) setminus x) in
+		(IntersectSizeUpper(xs setminus x, ys)))
+
+}
+// Proof using non-pure function (TODO delete if above is okay)
+// ghost
+// ensures len(xs intersection ys) <= len(xs)
+// decreases xs
+// func IntersectSizeUpper(xs, ys set[int]) Unit {
+// 	if !IsEmpty(xs) {
+// 		ghost x := choose(xs)
+// 		assert (xs setminus Singleton(x)) intersection ys == (xs intersection ys) setminus Singleton(x)
+// 		return IntersectSizeUpper(xs setminus Singleton(x), ys)
+// 	}
+// }
+
+// SKIP: S2 lemma_len_subset corresponds to SubsetSize from S1
+
+// S2
+// The size of the difference xs - ys is less than or equal to the size of xs. 
+ghost
+ensures len(xs setminus ys) <= len(xs)
+decreases
+pure func SetminusSizeUpper(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// SKIP: S2: set_int_range, lemma_int_range correspond to SetRange from S1
+// SKIP: S2: lemma_subset_equality corresponds to SubsetEquality from S1
+
+// SKIP: S2: lemma_map_size (cannot pass function)
+
+// TODO Do we need lemmas to assert that union and intersect are commutative?
+
+// S2
+ghost
+ensures (xs union ys) union ys == xs union ys
+decreases
+pure func UnionAgain1(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures (xs union ys) union xs == xs union ys
+decreases
+pure func UnionAgain2(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures (xs intersection ys) intersection ys == (xs intersection ys)
+decreases
+pure func IntersectAgain1(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures (xs intersection ys) intersection xs == (xs intersection ys)
+decreases
+pure func IntersectAgain2(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+// If ys contains e, then the difference xs - ys does not contain e.
+ghost
+ensures e in ys ==> !(e in (xs setminus ys))
+decreases
+pure func SetDifference2(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// SKIP S2: lemma_set_disjoint (no notion of disjoint in Gobra)
+// SKIP S2: lemma_set_empty_equivalency_len (unclear how it ties to the rest,
+// since we already consider IsEmpty() and Choose())
+
+// SKIP S2: lemma_set_disjoint_lens (no notion of disjoint in Gobra)
+
+// S2 (proves slightly different version)
+ghost
+ensures len(xs union ys) == len(xs) + len(ys) - len(xs intersection ys)
+decreases
+pure func UnionSizeEq(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures len(xs setminus ys) == len(xs) - len(xs intersection ys)
+ensures len(xs setminus ys) + len(ys setminus xs) + len(xs intersection ys) == len(xs union ys)
+decreases
+pure func SetminusSize(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// SKIP: S2: axiom_is_empty (seems to be more or less choose)
+// SKIP: S2: check_argument_is_set<A> (seems to be specific to Verus)
+// SKIP: S2: Macros (seems to be specific to Verus)

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -1,0 +1,173 @@
+// This package defines lemmas for sets commonly used in specifications.
+package sets
+
+// TODO Add proper attribution
+// SO Not taken from outside sources
+// S1 https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
+
+// SO
+// TODO Figure out how to import these from verify.gobra
+type Unit struct{}
+
+ghost
+requires b
+decreases
+pure func Asserting(ghost b bool) Unit {
+	return Unit{}
+}
+
+// SKIP S1: LemmaSubset<T>, quantified definition of subset
+
+// SO
+// Returns whether x is a proper subset of y.
+ghost
+decreases
+pure func IsProperSubset(x, y set[int]) bool {
+	return x subset y && x != y
+}
+
+// SO
+// Returns a singleton set containing x.
+ghost
+decreases
+pure func Singleton(x int) set[int] {
+	return set[int] {x}
+}
+
+// S0
+// Returns an empty set.
+ghost
+decreases
+pure func Empty() set[int] {
+	return set[int] {}
+}
+
+// S0/S1
+// Returns an element from a non-empty set.
+ghost
+decreases
+requires len(xs) != 0
+ensures x in xs
+ensures len(xs) == 1 ==> xs == Singleton(x)
+pure func choose(xs set[int]) (x int)
+
+// TODO Get IsProperSubset case to verify
+// S1
+// If x is a subset of y, then the size of x is less than or equal to the size of y.
+// If x is a strict subset of y, then the size of x is less than to the size of y.
+// ghost
+// decreases x, y
+// ensures x subset y ==> len(x) <= len(y)
+// ensures IsProperSubset(x, y) ==> len(x) < len(y)
+// func SubsetSize(x, y set[int]) Unit {
+	// if len(x) != 0 {
+		// ghost e := choose(x)
+		// SubsetSize(x setminus set[int] {e}, y setminus set[int] {e})
+	// }
+	// return Unit{}
+// }
+
+// S1
+// If x is a subset of y and both have the same size, they are equal.
+ghost
+requires x subset y
+requires len(x) == len(y)
+ensures x == y
+decreases
+pure func SubsetEquality(x, y set[int]) Unit {
+	return Asserting(len(y setminus x) == len(y) - len(x))
+}
+
+// S1
+// A singleton set has a size of 1.
+ghost
+requires x == Singleton(e)
+ensures len(x) == 1
+decreases
+pure func SingletonSize(x set[int], e int) Unit {
+	return Unit{}
+}
+
+
+// TODO Prove this (Dafny Proof uses strict SubsetSize)
+// S1
+// Elements in a singleton set are equal to each other.
+// ghost
+// requires len(x) == 1
+// requires a in x
+// requires b in x
+// ensures a == b
+// pure func SingletonEquality(x set[int], a, b int) Unit {
+// 	return Unit{}
+// }
+
+// SKIP S1: IsSingleton (quantified predicate)
+// SKIP S1: LemmaIsSingleton (uses IsSingleton)
+// NOTE S1: ExtractFromNonEmptySet and S1: ExtractFromSingleton are in choose
+
+// SKIP S1: MapSize<> (no Injective() defined)
+// SKIP S1: Map<> (no Injective() defined)
+// SKIP S1: LemmaFilterSize<> (not sure whether ~>/passing functions exists in Gobra)
+// SKIP S1: Filter (not sure whether ~>/passing functions exists in Gobra)
+
+// S1
+// The size of a union of two sets is greater than or equal to the size of
+// either individual set.
+ghost
+ensures len(xs union ys) >= len(xs)
+ensures len(xs union ys) >= len(ys)
+decreases ys
+pure func LemmaUnionSize(xs, ys set[int]) Unit {
+	return len(ys) == 0 ? Unit{} :
+		let y := choose(ys) in
+		(let yr := ys setminus Singleton(y) in
+		(y in xs ?
+			(let xr := xs setminus Singleton(y) in
+			(let _ := Asserting(xr union yr == xs union ys setminus Singleton(y)) in LemmaUnionSize(xr, yr))) :
+			(let _ := Asserting(xs union yr == xs union ys setminus Singleton(y)) in LemmaUnionSize(xs, yr))))
+}
+// Proof using non-pure function (TODO delete if above is okay)
+// func LemmaUnionSize(xs, ys set[int]) Unit {
+// 	if len(ys) != 0 {
+// 		ghost y := choose(ys)
+// 		ghost yr := ys setminus Singleton(y)
+// 		if y in xs {
+// 			ghost xr := xs setminus Singleton(y)
+// 			assert xr union yr == xs union ys setminus Singleton(y)
+// 			LemmaUnionSize(xr, yr)
+// 		} else {
+// 			assert xs union yr == xs union ys setminus Singleton(y)
+// 			LemmaUnionSize(xs, yr)
+// 		}
+// 	}
+// }
+
+
+// S1
+// Construct a set with all integers in the range [a, b).
+ghost
+requires a <= b
+ensures forall i int :: { i in s } (a <= i && i < b) == i in s
+ensures len(s) == b - a
+decreases b - a
+pure func SetRange(a, b int) (s set[int]) {
+	return a == b ? Empty() : Singleton(a) union SetRange(a + 1, b)
+}
+
+// S1
+// Construct a set with all integers in the range [0, n).
+ghost
+requires n >= 0
+ensures forall i int :: {i in s} (0 <= i && i < n) == i in s
+ensures len(s) == n
+pure func SetRangeFromZero(n int) (s set[int]) {
+	return SetRange(0, n)
+}
+
+// TODO S1: LemmaBoundedSetSize (Dafny proof requires LemmaSubsetSize +
+// contains unclear forall in proof)
+
+// SKIP S1: LemmaGreatestImplies{Minimal, Maximal}, LemmaMaximalEquivalentGreatest
+// LemmaMinimalEquivalentLeast, LeammLeastIsUnique, LemmaGreatestIsUnique, LemmaMinimalIsUnique
+// LemmaMaximalIsUnique, LemmaFindUniqueMinimal, LemmaFindUniqueMaximal
+// since Orderings are not defined

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -6,6 +6,7 @@ package sets
 // S1 https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
 // S2 https://github.com/verus-lang/verus/blob/main/source/pervasive/set_lib.rs
 // S3 https://why3.lri.fr/stdlib/set.html
+// S4 https://github.com/viperproject/silicon/blob/master/src/main/resources/dafny_axioms/sets.vpr
 
 
 // TODO Go through axiomization of sets
@@ -33,12 +34,73 @@ func TODO()
 
 // SKIP S1: LemmaSubset<T>; implemented below as Subset from S3
 
+// S4: in_empty_set => InEmpty
+// S4: empty_set_cardinality: (Set_card(s) == 0 <==> s == Set_empty()) is
+// expressed by EmptySet and EmptyIsEmptySet. (Set_card(s) != 0 ==> exists e: E :: {Set_in(e, s)} Set_in(e, s))
+// is expressed by choose.
+// S4: in_singleton_set: expressed by SingletonSet
+// S4: in_singleton_set_equality: expressed by SingletonEquality
+// S4: singleton_set_cardinality: expressed by IsSingleton
+// S4: in_unionone_same: expressed by Add
+// S4: in_unionone_other: expressed by InAddOther
+// S4: invariance_in_unionone: expressed by InvarianceInAdd
+// S4: unionone_cardinality_invariant + unionone_cardinality_changed: expressed by CardinalAdd
+// S4: in_union_in_one: expressed by InUnionInOne
+// S4: in_left_in_union/in_right_in_union seems to be a case distinction of InUnionInOne, hence skipped
+// S4: disjoint_sets_difference_union: commented; what are a and b supposed to be?
+// S4: union_left_idempotency/union_right_idempotency -> same name
+// S4: intersection_left_idempotency/intersection_right_idempotency -> same name
+// S4: cardinality_sums -> UnionSizeEq
+// S4: subset_definition -> Subset()
+// S4: equality_definition/native_equality -> SetEquality
+// S4: disjointness_definition: Defined disjointness in terms of intersection instead of more quantifiers
+// S4: cardinality_difference -> SetminusSize
+
+// S4
+ghost
+ensures (xs == ys) == (forall e int :: {e in xs} {e in ys} ((e in xs) == (e in ys)))
+decreases
+pure func SetEquality(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S4
+ghost
+ensures e in (xs intersection ys) == ((e in xs) && (e in ys))
+decreases
+pure func InIntersectionInBoth(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// S4
+ghost
+ensures (e in (xs union ys)) == ((e in xs) || (e in ys))
+decreases
+pure func InUnionInOne(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// S4
+// The length of a set is non-negative.
+ghost
+ensures len(x) >= 0
+pure func LengthNonNegative(x set[int]) Unit {
+	return Unit{}
+}
+
 // SO
 // Returns whether x is a proper subset of y.
 ghost
 decreases
 pure func IsProperSubset(x, y set[int]) bool {
 	return x subset y && x != y
+}
+
+// S4
+ghost
+decreases
+pure func AreDisjoint(xs, ys set[int]) bool {
+	return IsEmpty(xs intersection ys)
 }
 
 // S1
@@ -52,6 +114,7 @@ pure func IsSingleton(x set[int]) bool {
 // Returns a singleton set containing x.
 ghost
 ensures IsSingleton(result)
+ensures x in result
 decreases
 pure func SingletonSet(x int) (result set[int]) {
 	return set[int] {x}
@@ -59,27 +122,25 @@ pure func SingletonSet(x int) (result set[int]) {
 
 // S1
 // Elements in a singleton set are equal to each other
-// TODO Prove this: Dafny proof requires strict case of SubsetSize
-// ghost
-// requires IsSingleton(x)
-// requires a in x
-// requires b in x
-// ensures a == b
-// decreases
-// pure func SingletonEquality(x set[int], a int, b int) Unit {
-// 	return Unit{}
-// }
+ghost
+requires IsSingleton(x)
+requires a in x
+requires b in x
+ensures a == b
+decreases
+pure func SingletonEquality(x set[int], a int, b int) Unit {
+	return let _ := choose(x) in Unit{}
+}
 
 // S0
 // If a is in a singleton set x, then x is of the form {a}
-// TODO Prove this
-// ghost
-// requires IsSingleton(x)
-// requires a in x
-// ensures x == SingletonSet(a)
-// pure func SingletonIsSingletonSet(x set[int], a int) Unit {
-// 	return Unit{}
-// }
+ghost
+requires IsSingleton(x)
+requires a in x
+ensures x == SingletonSet(a)
+pure func SingletonIsSingletonSet(x set[int], a int) Unit {
+	return let _ := choose(x) in Unit{}
+}
 
 // S2
 // Returns whether x is empty.
@@ -98,13 +159,13 @@ pure func EmptySet() (result set[int]) {
 	return set[int] {}
 }
 
-// S3
+// S3, S4
 // Nothing can be an element of the empty set.
 ghost
 requires IsEmpty(x)
 ensures !(e in x)
 decreases
-pure func ElementNotInEmpty(x set[int], e int) Unit {
+pure func InEmpty(x set[int], e int) Unit {
 	return Unit{}
 }
 
@@ -338,19 +399,21 @@ pure func SetminusSizeUpper(xs, ys set[int]) Unit {
 
 // TODO Do we need lemmas to assert that union and intersect are commutative?
 
-// S2
+// S4: union_right_idempotency -> 
+
+// S2/S4
 ghost
 ensures (xs union ys) union ys == xs union ys
 decreases
-pure func UnionAgain1(xs, ys set[int]) Unit {
+pure func UnionRightIdempotency(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-// S2
+// S2/S4
 ghost
-ensures (xs union ys) union xs == xs union ys
+ensures xs union (xs union ys) == xs union ys
 decreases
-pure func UnionAgain2(xs, ys set[int]) Unit {
+pure func UnionLeftIdempotency(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
@@ -358,24 +421,34 @@ pure func UnionAgain2(xs, ys set[int]) Unit {
 ghost
 ensures (xs intersection ys) intersection ys == (xs intersection ys)
 decreases
-pure func IntersectAgain1(xs, ys set[int]) Unit {
+pure func IntersectionRightIdempotency(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
 // S2
 ghost
-ensures (xs intersection ys) intersection xs == (xs intersection ys)
+ensures xs intersection (xs intersection ys) == (xs intersection ys)
 decreases
-pure func IntersectAgain2(xs, ys set[int]) Unit {
+pure func IntersectionLeftIdempotency(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+
+// S4
+ghost
+ensures (e in (xs setminus ys)) == ((e in xs) && !(e in ys))
+decreases
+pure func InDifference(xs, ys set[int], e int) Unit {
 	return Unit{}
 }
 
 // S2
 // If ys contains e, then the difference xs - ys does not contain e.
 ghost
-ensures e in ys ==> !(e in (xs setminus ys))
+requires e in ys
+ensures !(e in (xs setminus ys))
 decreases
-pure func SetDifference2(xs, ys set[int], e int) Unit {
+pure func NotInDifference(xs, ys set[int], e int) Unit {
 	return Unit{}
 }
 
@@ -454,6 +527,7 @@ pure func SubsetTransitive(xs, ys, zs set[int]) Unit {
 ghost
 // Need this post-condition to verify CardinalAdd
 ensures (x in xs) ==> res == xs
+ensures x in res
 decreases
 pure func Add(xs set[int], x int) (res set[int]) {
 	return xs union SingletonSet(x)
@@ -465,6 +539,23 @@ pure func Add(xs set[int], x int) (res set[int]) {
 // SKIP S3: mem_singleton: contains quantifiers; unsure how to formalize singletons:
 // as set of length one? forall x, y. y in Singleton(x) => x = y (S3)?
 // forall x, y: x in Singleton(_) && y in Singleton(_) => x == y (S1, S2)?
+
+// S4
+ghost
+ensures (e1 in Add(xs, e2)) == ((e1 == e2) || e1 in xs)
+decreases
+pure func InAddOther(xs set[int], e1, e2 int) Unit {
+	return Unit{}
+}
+
+// S4
+ghost
+requires e1 in xs
+ensures e1 in Add(xs, e2)
+decreases
+pure func InvarianceInAdd(xs set[int], e1, e2 int) Unit {
+	return Unit{}
+}
 
 // S3
 // Remove the element x from the set xs.

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -8,6 +8,8 @@ package sets
 // S3 https://why3.lri.fr/stdlib/set.html
 
 
+// (How) Should we transform the axiomization of sets into lemmas?
+
 // TODO Restructure, rename and properly document definitions at the end
 // (in particular consistency in names of functions, arguments, variables)
 

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -9,13 +9,13 @@ package sets
 // S4 https://github.com/viperproject/silicon/blob/master/src/main/resources/dafny_axioms/sets.vpr
 
 
-// TODO Restructure, rename and properly document definitions at the end
-// (in particular consistency in names of functions, arguments (names/order), variables)
-
+// TODO Improve comments
 // QUES Should we use unicode comments like ∀ x,y : set[int]. |x| ≤ |y|?
 
-// SO
 // TODO Figure out how to import these from verify.gobra
+// SO
+// Helpers
+// *******
 type Unit struct{}
 
 ghost
@@ -30,103 +30,18 @@ ensures false
 decreases _
 func TODO()
 
-
-// S4
-ghost
-ensures (xs == ys) == (forall e int :: {e in xs} {e in ys} ((e in xs) == (e in ys)))
-decreases
-pure func SetEquality(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S4
-ghost
-ensures e in (xs intersection ys) == ((e in xs) && (e in ys))
-decreases
-pure func InIntersectionInBoth(xs, ys set[int], e int) Unit {
-	return Unit{}
-}
-
-// S4
-ghost
-ensures (e in (xs union ys)) == ((e in xs) || (e in ys))
-decreases
-pure func InUnionInOne(xs, ys set[int], e int) Unit {
-	return Unit{}
-}
-
-// S4
-// The length of a set is non-negative.
-ghost
-ensures len(x) >= 0
-pure func LengthNonNegative(x set[int]) Unit {
-	return Unit{}
-}
-
-// SO
-// Returns whether x is a proper subset of y.
-ghost
-decreases
-pure func IsProperSubset(x, y set[int]) bool {
-	return x subset y && x != y
-}
-
-// S4
-ghost
-decreases
-pure func AreDisjoint(xs, ys set[int]) bool {
-	return IsEmpty(xs intersection ys)
-}
-
-// S1
-ghost
-decreases
-pure func IsSingleton(x set[int]) bool {
-	return len(x) == 1
-}
-
-// SO
-// Returns a singleton set containing x.
-ghost
-ensures IsSingleton(result)
-ensures x in result
-decreases
-pure func SingletonSet(x int) (result set[int]) {
-	return set[int] {x}
-}
-
-// S1
-// Elements in a singleton set are equal to each other
-ghost
-requires IsSingleton(x)
-requires a in x
-requires b in x
-ensures a == b
-decreases
-pure func SingletonEquality(x set[int], a int, b int) Unit {
-	return let _ := choose(x) in Unit{}
-}
-
-// S0
-// If a is in a singleton set x, then x is of the form {a}
-ghost
-requires IsSingleton(x)
-requires a in x
-ensures x == SingletonSet(a)
-pure func SingletonIsSingletonSet(x set[int], a int) Unit {
-	return let _ := choose(x) in Unit{}
-}
-
+// Empty set
+// *********
 // S2
-// Returns whether x is empty.
+// A set is empty if it has length 0.
 ghost
 decreases
-pure func IsEmpty(x set[int]) bool {
-	return len(x) == 0
+pure func IsEmpty(xs set[int]) bool {
+	return len(xs) == 0
 }
 
 // S0
-// Returns an empty set.
+// Returns an empty set {}.
 ghost
 ensures IsEmpty(result)
 decreases
@@ -134,129 +49,114 @@ pure func EmptySet() (result set[int]) {
 	return set[int] {}
 }
 
-// S3, S4
-// Nothing can be an element of the empty set.
+// An empty set has length 0.
 ghost
-requires IsEmpty(x)
-ensures !(e in x)
+requires xs == EmptySet()
+ensures IsEmpty(xs)
 decreases
-pure func InEmpty(x set[int], e int) Unit {
+pure func EmptyLen(xs set[int]) Unit {
 	return Unit{}
 }
 
 // S3
 // A set of length 0 is the empty set.
 ghost
-requires IsEmpty(x)
-ensures x == EmptySet()
+requires IsEmpty(xs)
+ensures xs == EmptySet()
 decreases
-pure func EmptyIsEmptySet(x set[int]) Unit {
+pure func EmptyIsEmptySet(xs set[int]) Unit {
 	return Unit{}
 }
 
-// S0/S1
-// Returns an element from a non-empty set.
+// S3, S4
+// Nothing can be an element of the empty set.
 ghost
-requires !IsEmpty(xs)
-ensures x in xs
-ensures len(xs) == 1 ==> xs == SingletonSet(x)
+requires IsEmpty(xs)
+ensures !(e in xs)
 decreases
-pure func choose(xs set[int]) (x int)
-
-// TODO Get IsProperSubset case to verify
-// S1
-// If x is a subset of y, then the size of x is less than or equal to the size of y.
-// If x is a strict subset of y, then the size of x is less than to the size of y.
-// ghost
-// decreases x, y
-// ensures x subset y ==> len(x) <= len(y)
-// ensures IsProperSubset(x, y) ==> len(x) < len(y)
-// func SubsetSize(x, y set[int]) Unit {
-	// if len(x) != 0 {
-		// ghost e := choose(x)
-		// SubsetSize(x setminus set[int] {e}, y setminus set[int] {e})
-	// }
-	// return Unit{}
-// }
-
-// S1
-// If x is a subset of y and both have the same size, they are equal.
-ghost
-requires x subset y
-requires len(x) == len(y)
-ensures x == y
-decreases
-pure func SubsetEquality(x, y set[int]) Unit {
-	return Asserting(len(y setminus x) == len(y) - len(x))
-}
-
-// S1
-// A singleton set has a size of 1.
-ghost
-requires x == SingletonSet(e)
-ensures len(x) == 1
-decreases
-pure func SingletonSize(x set[int], e int) Unit {
+pure func NotInEmpty(xs set[int], e int) Unit {
 	return Unit{}
 }
 
+// Singleton set
+// **************
+// S1
+// A set is a singleton if it has length 1.
+ghost
+decreases
+pure func IsSingleton(xs set[int]) bool {
+	return len(xs) == 1
+}
 
-// TODO Prove this (Dafny Proof uses strict SubsetSize)
+// SO
+// Returns a singleton set containing x.
+ghost
+ensures IsSingleton(result)
+ensures e in result
+decreases
+pure func SingletonSet(e int) (result set[int]) {
+	return set[int] {e}
+}
+
+// S1
+// A singleton set has a length of 1.
+ghost
+requires xs == SingletonSet(e)
+ensures IsSingleton(xs)
+decreases
+pure func SingletonLen(xs set[int], e int) Unit {
+	return Unit{}
+}
+
+// S0
+// If a is in a singleton set x, then x is of the form {a}
+ghost
+requires IsSingleton(xs)
+requires e in xs
+ensures xs == SingletonSet(e)
+decreases
+pure func SingletonIsSingletonSet(xs set[int], e int) Unit {
+	return let _ := Choose(xs) in Unit{}
+}
+
 // S1
 // Elements in a singleton set are equal to each other.
-// ghost
-// requires len(x) == 1
-// requires a in x
-// requires b in x
-// ensures a == b
-// pure func SingletonEquality(x set[int], a, b int) Unit {
-// 	return Unit{}
-// }
-
-// S1
-// The size of a union of two sets is greater than or equal to the size of
-// either individual set.
 ghost
-ensures len(xs union ys) >= len(xs)
-ensures len(xs union ys) >= len(ys)
-decreases ys
-pure func UnionSizeLower(xs, ys set[int]) Unit {
-	return IsEmpty(ys) ? Unit{} :
-		let y := choose(ys) in
-		(let yr := Remove(ys, y) in
-		(y in xs ?
-			(let xr := Remove(xs, y) in
-			(let _ := Asserting(xr union yr == Remove(xs union ys, y)) in UnionSizeLower(xr, yr))) :
-			(let _ := Asserting(xs union yr == Remove(xs union ys, y)) in UnionSizeLower(xs, yr))))
+requires IsSingleton(xs)
+requires a in xs
+requires b in xs
+ensures a == b
+decreases
+pure func SingletonEquality(xs set[int], a int, b int) Unit {
+	return let _ := Choose(xs) in Unit{}
 }
 
+// Constructing new sets
+// **********************
 
 // S1
 // Construct a set with all integers in the range [a, b).
 ghost
 requires a <= b
-ensures forall i int :: { i in s } (a <= i && i < b) == i in s
-ensures len(s) == b - a
+ensures forall i int :: { i in result } (a <= i && i < b) == i in result
+ensures len(result) == b - a
 decreases b - a
-pure func SetRange(a, b int) (s set[int]) {
-	return a == b ? EmptySet() : Add(SetRange(a + 1, b), a)
+pure func Range(a, b int) (result set[int]) {
+	return a == b ? EmptySet() : Add(Range(a + 1, b), a)
 }
 
 // S1
 // Construct a set with all integers in the range [0, n).
 ghost
 requires n >= 0
-ensures forall i int :: {i in s} (0 <= i && i < n) == i in s
-ensures len(s) == n
+ensures forall i int :: { i in result } (0 <= i && i < n) == i in result
+ensures len(result) == n
 decreases
-pure func SetRangeFromZero(n int) (s set[int]) {
-	return SetRange(0, n)
+pure func RangeFromZero(n int) (result set[int]) {
+	return Range(0, n)
 }
 
-// TODO Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
-// contains unclear forall in proof)
-
-// TODO: Do we even want to bother with multisets?
+// TODO: Do we want to implement multisets?
 // S2
 // Converts a set into a multiset where each element from the set has
 // multiplicity 1 and any other element has multiplicity 0.
@@ -266,147 +166,55 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 // decreases s
 // pure func ToMultiset(s set[int]) (ms mset[int]) {
 // 	return IsEmpty(s) ? mset[int] {} :
-// 		let x := choose(s) in
+// 		let x := Choose(s) in
 // 		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
 // }
 
-// S2
-// The size of a union of two sets is less than or equal to the size of
-// both individual sets combined.
+
+// choose axiom
+// ************
+// S0/S1
+// Returns an element from a non-empty set.
 ghost
-ensures len(xs union ys) <= len(xs) + len(ys)
+requires !IsEmpty(xs)
+ensures e in xs
+ensures IsSingleton(xs) ==> xs == SingletonSet(e)
 decreases
-pure func UnionSizeUpper(xs, ys set[int]) Unit {
+pure func Choose(xs set[int]) (e int)
+
+// TODO Is this needed? It feels similar to what we get from calling Choose
+// S3
+// If xs is a Singleton, and x is in xs, then Choose(xs) will always return x.
+ghost
+requires IsSingleton(xs)
+requires e in xs
+ensures Choose(xs) == e
+decreases
+pure func ChooseFromSingleton(xs set[int], e int) Unit {
 	return Unit{}
 }
 
-// S2
-// The size of the intersection of xs and ys is less than or equal to the
-// size of xs.
+// General definitions and properties
+// **********************************
+// S4
+// Returns whether xs and ys are disjoint sets.
 ghost
-ensures len(xs intersection ys) <= len(xs)
-decreases xs
-pure func IntersectSizeUpper(xs, ys set[int]) Unit {
-	return IsEmpty(xs) ? Unit{} :
-		let x := choose(xs) in
-		(let _ := Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
-		(IntersectSizeUpper(Remove(xs, x), ys)))
-
-}
-
-
-// S2
-// The size of the difference xs - ys is less than or equal to the size of xs. 
-ghost
-ensures len(xs setminus ys) <= len(xs)
 decreases
-pure func SetminusSizeUpper(xs, ys set[int]) Unit {
-	return Unit{}
+pure func AreDisjoint(xs, ys set[int]) bool {
+	return IsEmpty(xs intersection ys)
 }
-
-ghost
-ensures (xs union ys) == (ys union xs)
-decreases
-pure func UnionCommutativity(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-ghost
-ensures (xs intersection ys) == (ys intersection xs)
-decreases
-pure func IntersectionCommutativity(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S2/S4
-ghost
-ensures (xs union ys) union ys == xs union ys
-decreases
-pure func UnionRightIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S2/S4
-ghost
-ensures xs union (xs union ys) == xs union ys
-decreases
-pure func UnionLeftIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S2
-ghost
-ensures (xs intersection ys) intersection ys == (xs intersection ys)
-decreases
-pure func IntersectionRightIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S2
-ghost
-ensures xs intersection (xs intersection ys) == (xs intersection ys)
-decreases
-pure func IntersectionLeftIdempotency(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
 
 // S4
+// Definition of set equality.
 ghost
-ensures (e in (xs setminus ys)) == ((e in xs) && !(e in ys))
+ensures (xs == ys) == (forall e int :: {e in xs} {e in ys} ((e in xs) == (e in ys)))
 decreases
-pure func InDifference(xs, ys set[int], e int) Unit {
+pure func SetEquality(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-// S2
-// If ys contains e, then the difference xs - ys does not contain e.
-ghost
-requires e in ys
-ensures !(e in (xs setminus ys))
-decreases
-pure func NotInDifference(xs, ys set[int], e int) Unit {
-	return Unit{}
-}
-
-// S2
-ghost
-requires AreDisjoint(xs, ys)
-ensures (xs union ys) setminus xs == ys
-ensures (xs union ys) setminus ys == xs
-decreases
-pure func SetDisjoint(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-ghost
-requires AreDisjoint(xs, ys)
-ensures len(xs union ys) == len(xs) + len(ys)
-decreases
-pure func DisjointUnionSize(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S2 (proves slightly different version)
-ghost
-ensures len(xs union ys) == len(xs) + len(ys) - len(xs intersection ys)
-decreases
-pure func UnionSizeEq(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-// S2
-ghost
-ensures len(xs setminus ys) == len(xs) - len(xs intersection ys)
-ensures len(xs setminus ys) + len(ys setminus xs) + len(xs intersection ys) == len(xs union ys)
-decreases
-pure func SetminusSize(xs, ys set[int]) Unit {
-	return Unit{}
-}
-
-
-// S3: Finite sets
-// ***************
+// Subset
+// ******
 // S3
 // Definition of subset without quantifiers.
 ghost
@@ -414,7 +222,7 @@ requires e in xs
 requires xs subset ys
 ensures e in ys
 decreases
-pure func Subset(xs, ys set[int], e int) Unit {
+pure func InSubset(xs, ys set[int], e int) Unit {
 	return Unit{}
 }
 
@@ -438,51 +246,177 @@ pure func SubsetTransitive(xs, ys, zs set[int]) Unit {
 	return Unit{}
 }
 
+// S1
+// If x is a subset of y and both have the same length, they are equal.
+ghost
+requires xs subset ys
+requires len(xs) == len(ys)
+ensures xs == ys
+decreases
+pure func SubsetEquality(xs, ys set[int]) Unit {
+	return Asserting(len(ys setminus xs) == len(ys) - len(xs))
+}
+
+// SO
+// Returns whether x is a proper subset of y.
+ghost
+decreases
+pure func IsProperSubset(xs, ys set[int]) bool {
+	return xs subset ys && xs != ys
+}
+
+// Union
+// *****
+// S4
+// If an e is in the union of xs and ys, then it must be in xs or ys.
+ghost
+ensures (e in (xs union ys)) == ((e in xs) || (e in ys))
+decreases
+pure func InUnionInOne(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// Union is commutative.
+ghost
+ensures (xs union ys) == (ys union xs)
+decreases
+pure func UnionCommutativity(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2/S4
+ghost
+ensures (xs union ys) union ys == xs union ys
+decreases
+pure func UnionRightIdempotency(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2/S4
+ghost
+ensures xs union (xs union ys) == xs union ys
+decreases
+pure func UnionLeftIdempotency(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// Add (union with singleton)
+// **************************
 // S3 (add, add_def)
 // Add an element x to the set xs.
 ghost
 // Need this post-condition to verify CardinalAdd
-ensures (x in xs) ==> res == xs
-ensures x in res
+ensures (e in xs) ==> res == xs
+ensures e in res
 decreases
-pure func Add(xs set[int], x int) (res set[int]) {
-	return xs union SingletonSet(x)
+pure func Add(xs set[int], e int) (res set[int]) {
+	return xs union SingletonSet(e)
 }
 
 // S4
 ghost
-ensures (e1 in Add(xs, e2)) == ((e1 == e2) || e1 in xs)
+ensures (a in Add(xs, b)) == ((a == b) || a in xs)
 decreases
-pure func InAddOther(xs set[int], e1, e2 int) Unit {
+pure func InAdd(xs set[int], a, b int) Unit {
 	return Unit{}
 }
 
 // S4
 ghost
-requires e1 in xs
-ensures e1 in Add(xs, e2)
+requires a in xs
+ensures a in Add(xs, b)
 decreases
-pure func InvarianceInAdd(xs set[int], e1, e2 int) Unit {
+pure func InvarianceInAdd(xs set[int], a, b int) Unit {
 	return Unit{}
 }
 
+// Remove (setminus with singleton)
+// ********************************
 // S3
 // Remove the element x from the set xs.
 // TODO Should we add something like ensures !(x in xs) ==> xs == Remove(xs, x)
 // like we did for Add?
 ghost
 decreases
-pure func Remove(xs set[int], x int) set[int] {
-	return xs setminus SingletonSet(x)
+pure func Remove(xs set[int], e int) set[int] {
+	return xs setminus SingletonSet(e)
 }
+
+// Intersection
+// ************
+ghost
+ensures (xs intersection ys) == (ys intersection xs)
+decreases
+pure func IntersectionCommutativity(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures (xs intersection ys) intersection ys == (xs intersection ys)
+decreases
+pure func IntersectionRightIdempotency(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures xs intersection (xs intersection ys) == (xs intersection ys)
+decreases
+pure func IntersectionLeftIdempotency(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+
+// Setminus
+// ********
+// S4
+ghost
+ensures (e in (xs setminus ys)) == ((e in xs) && !(e in ys))
+decreases
+pure func InSetminus(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// S2
+// If ys contains e, then the difference xs - ys does not contain e.
+ghost
+requires e in ys
+ensures !(e in (xs setminus ys))
+decreases
+pure func NotInSetminus(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// Relating multiple operations
+// ****************************
+// S4
+ghost
+ensures e in (xs intersection ys) == ((e in xs) && (e in ys))
+decreases
+pure func InIntersectionInBoth(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+
+// S2
+ghost
+requires AreDisjoint(xs, ys)
+ensures (xs union ys) setminus xs == ys
+ensures (xs union ys) setminus ys == xs
+decreases
+pure func DisjointUnionSetminus(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
 
 // S3
 // If x is in the set xs, removing and adding it back in does not change the set
 ghost
-requires x in xs
-ensures Add(Remove(xs, x), x) == xs
+requires e in xs
+ensures Add(Remove(xs, e), e) == xs
 decreases
-pure func AddRemove(xs set[int], x int) Unit {
+pure func AddRemove(xs set[int], e int) Unit {
 	return Unit{}
 }
 
@@ -490,20 +424,19 @@ pure func AddRemove(xs set[int], x int) Unit {
 // If we remove x from the set xs, it doesn't matter whether we have added x
 // to it before.
 ghost
-ensures Remove(Add(xs, x), x) == Remove(xs, x)
+ensures Remove(Add(xs, e), e) == Remove(xs, e)
 decreases
-pure func RemoveAdd(xs set[int], x int) Unit {
+pure func RemoveAdd(xs set[int], e int) Unit {
 	return Unit{}
 }
 
 // S3
 ghost
-ensures Remove(xs, x) subset xs
+ensures Remove(xs, e) subset xs
 decreases
-pure func SubsetRemove(xs set[int], x int) Unit {
+pure func SubsetRemove(xs set[int], e int) Unit {
 	return Unit{}
 }
-
 
 // TODO Should we merge SubsetUnion1 and SubsetUnion2?
 // S3
@@ -521,6 +454,7 @@ decreases
 pure func SubsetUnion2(xs, ys set[int]) Unit {
 	return Unit{}
 }
+
 
 // S3
 ghost
@@ -547,41 +481,135 @@ pure func SubsetSetminus(xs, ys set[int]) Unit {
 }
 
 
-// S3
+// Length
+// ******
+
+// S4
+// The length of a set is non-negative.
 ghost
 ensures len(xs) >= 0
 decreases
-pure func CardinalNonneg(xs set[int]) Unit {
+pure func NonNegativeLen(xs set[int]) Unit {
 	return Unit{}
 }
 
+// TODO Get IsProperSubset case to verify
+// S1
+// If x is a subset of y, then the length of x is less than or equal to the length of y.
+// If x is a strict subset of y, then the length of x is less than to the length of y.
+// ghost
+// decreases x, y
+// ensures x subset y ==> len(x) <= len(y)
+// ensures IsProperSubset(x, y) ==> len(x) < len(y)
+// func SubsetLen(x, y set[int]) Unit {
+	// if len(x) != 0 {
+		// ghost e := Choose(x)
+		// SubsetLen(x setminus set[int] {e}, y setminus set[int] {e})
+	// }
+	// return Unit{}
+// }
+
+// S1
+// The length of a union of two sets is greater than or equal to the length of
+// either individual set.
+ghost
+ensures len(xs union ys) >= len(xs)
+ensures len(xs union ys) >= len(ys)
+decreases ys
+pure func UnionLenLower(xs, ys set[int]) Unit {
+	return IsEmpty(ys) ? Unit{} :
+		let y := Choose(ys) in
+		(let yr := Remove(ys, y) in
+		(y in xs ?
+			(let xr := Remove(xs, y) in
+			(let _ := Asserting(xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
+			(let _ := Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+}
+
+// S2
+// The length of a union of two sets is less than or equal to the length of
+// both individual sets combined.
+ghost
+ensures len(xs union ys) <= len(xs) + len(ys)
+decreases
+pure func UnionLenUpper(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+// The length of the intersection of xs and ys is less than or equal to the
+// length of xs.
+ghost
+ensures len(xs intersection ys) <= len(xs)
+decreases xs
+pure func IntersectLenUpper(xs, ys set[int]) Unit {
+	return IsEmpty(xs) ? Unit{} :
+		let x := Choose(xs) in
+		(let _ := Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(IntersectLenUpper(Remove(xs, x), ys)))
+}
+
+// S2
+// The length of the difference xs - ys is less than or equal to the length of xs. 
+ghost
+ensures len(xs setminus ys) <= len(xs)
+decreases
+pure func SetminusLenUpper(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2 (proves slightly different version)
+ghost
+ensures len(xs union ys) == len(xs) + len(ys) - len(xs intersection ys)
+decreases
+pure func UnionLenEq(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S2
+ghost
+ensures len(xs setminus ys) == len(xs) - len(xs intersection ys)
+ensures len(xs setminus ys) + len(ys setminus xs) + len(xs intersection ys) == len(xs union ys)
+decreases
+pure func SetminusLenEq(xs, ys set[int]) Unit {
+	return Unit{}
+}
 
 // S3
 ghost
-ensures (x in xs) ==> (len(Add(xs, x)) == len(xs))
-ensures !(x in xs) ==> (len(Add(xs, x)) == len(xs) + 1)
+ensures (e in xs) ==> (len(Add(xs, e)) == len(xs))
+ensures !(e in xs) ==> (len(Add(xs, e)) == len(xs) + 1)
 decreases
-func CardinalAdd(xs set[int], x int) Unit {
+func AddLen(xs set[int], e int) Unit {
 	return Unit{}
 }
 
 // S3
 ghost
-ensures (x in xs) ==> (len(Remove(xs, x)) == len(xs) - 1)
-ensures !(x in xs) ==> (len(Remove(xs, x)) == len(xs))
+ensures (e in xs) ==> (len(Remove(xs, e)) == len(xs) - 1)
+ensures !(e in xs) ==> (len(Remove(xs, e)) == len(xs))
 decreases
-func CardinalRemove(xs set[int], x int) Unit {
+func RemoveLen(xs set[int], e int) Unit {
 	return Unit{}
 }
-// S3
-// If xs is a Singleton, and x is in xs, then choose(xs) will always return x.
+
 ghost
-requires len(xs) == 1
-ensures x in xs ==> choose(xs) == x
+requires AreDisjoint(xs, ys)
+ensures len(xs union ys) == len(xs) + len(ys)
 decreases
-pure func Cardinal1(xs set[int], x int) Unit {
+pure func DisjointUnionLen(xs, ys set[int]) Unit {
 	return Unit{}
 }
+
+// TODO Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
+// contains unclear forall in proof)
+// Dafny signature:
+//   lemma LemmaBoundedSetSize(x: set<int>, a: int, b: int)
+//     requires forall i {:trigger i in x} :: i in x ==> a <= i < b
+//     requires a <= b
+//     ensures |x| <= b - a
+
+// *****************
 
 // TODO S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
 // their post-condition; do we want these functions?

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -14,7 +14,6 @@
 // This package defines lemmas for sets commonly used in specifications.
 package sets
 
-// ##(-I ../)
 import utils "utils"
 
 // A set is empty if it has cardinality 0.
@@ -110,10 +109,10 @@ pure func RangeFromZero(n int) (result set[int]) {
 // Converts a set into a multiset where each element from the set has
 // multiplicity 1 and any other element has multiplicity 0.
 ghost
-ensures forall i int :: {i # ms} (i in s) ==> ((i # ms) == 1)
-ensures forall i int :: {i # ms} (!(i in s)) ==> ((i # ms) == 0)
+ensures forall i int :: {i # result} (i in s) ==> ((i # result) == 1)
+ensures forall i int :: {i # result} (!(i in s)) ==> ((i # result) == 0)
 decreases s
-pure func ToMultiset(s set[int]) (ms mset[int]) {
+pure func ToMultiset(s set[int]) (result mset[int]) {
 	return IsEmpty(s) ? mset[int] {} :
 		let x := choose(s) in
 		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
@@ -215,12 +214,12 @@ pure func UnionIsIdempotent(xs, ys set[int]) utils.Unit {
 // Add x to xs.
 ghost
 // Need this post-condition first to ensure the properties about the length.
-ensures (e in xs) ==> res == xs
-ensures (e in xs) ==> (len(res) == len(xs))
-ensures !(e in xs) ==> (len(res) == len(xs) + 1)
-ensures e in res
+ensures (e in xs) ==> result == xs
+ensures (e in xs) ==> (len(result) == len(xs))
+ensures !(e in xs) ==> (len(result) == len(xs) + 1)
+ensures e in result
 decreases
-pure func Add(xs set[int], e int) (res set[int]) {
+pure func Add(xs set[int], e int) (result set[int]) {
 	return xs union SingletonSet(e)
 }
 
@@ -364,20 +363,22 @@ pure func NonNegativeLen(xs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// QUES I cannot get the IsProperSubset case to verify; Verus doesn't include this case either. Do we skip it for now?
-// If x is a subset of y, then the cardinality of x is less than or equal to the cardinality of y.
-// {If x is a strict subset of y, then the cardinality of x is less than to the cardinality of y.}
-// ghost
-// decreases x, y
-// ensures x subset y ==> len(x) <= len(y)
-// ensures IsProperSubset(x, y) ==> len(x) < len(y)
-// func SubsetLen(x, y set[int]) utils.Unit {
-// 	if len(x) != 0 {
-// 		ghost e := choose(x)
-// 		SubsetLen(x setminus set[int] {e}, y setminus set[int] {e})
-// 	}
-// 	return utils.Unit{}
-// }
+// If xs is a subset of ys, then the cardinality of xs is less than or equal to the cardinality of ys.
+// If xs is a strict subset of ys, then the cardinality of xs is less than the cardinality of ys.
+ghost
+decreases xs, ys
+ensures xs subset ys ==> len(xs) <= len(ys)
+ensures IsProperSubset(xs, ys) ==> len(xs) < len(ys)
+pure func SubsetLen(xs, ys set[int]) utils.Unit {
+	return (!(xs subset ys) || len(xs) == 0) ? utils.Unit{} :
+		len(xs) == len(ys) ?
+			let _ := SubsetEquality(xs, ys) in
+			(let e := choose(xs) in
+			(SubsetLen(Remove(xs, e), Remove(ys, e)))) :
+
+			let e:= choose(xs) in
+			(SubsetLen(Remove(xs, e), Remove(ys, e)))			
+}
 
 // The cardinality of a union of two sets is greater than or equal to the cardinality of
 // either individual set.
@@ -469,14 +470,13 @@ pure func DisjointUnionLen(xs, ys set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
-// QUES Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
-// contains unclear forall in proof)
-// TODO If we do want this; make sure to call it something like BoundedSetLen to be consistent.
-// Dafny signature:
-//   lemma LemmaBoundedSetSize(x: set<int>, a: int, b: int)
-//     requires forall i {:trigger i in x} :: i in x ==> a <= i < b
-//     requires a <= b
-//     ensures |x| <= b - a
-
-// QUES S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
-// their post-condition; do we want these functions?
+// If xs solely contains integers in the range [a, b), then its size is 
+// bounded by b - a.
+ghost
+requires forall i int :: { i in xs } i in xs ==> (a <= i && i < b)
+requires a <= b
+ensures len(xs) <= b - a
+decreases
+pure func BoundedSetLen(xs set[int], a, b int) utils.Unit {
+	return SubsetLen(xs, Range(a, b))
+}

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -27,16 +27,16 @@ pure func IsEmpty(xs set[int]) bool {
 ghost
 ensures IsEmpty(result)
 decreases
-pure func EmptySet() (result set[int]) {
+pure func Empty() (result set[int]) {
 	return set[int]{}
 }
 
 // There is only one empty set.
 ghost
 requires IsEmpty(xs)
-ensures xs == EmptySet()
+ensures xs == Empty()
 decreases
-pure func EmptySetIsUnique(xs set[int]) utils.Unit {
+pure func EmptyIsUnique(xs set[int]) utils.Unit {
 	return utils.Unit{}
 }
 
@@ -93,7 +93,7 @@ ensures forall i int :: { i in result } (a <= i && i < b) == i in result
 ensures len(result) == b - a
 decreases b - a
 pure func Range(a, b int) (result set[int]) {
-	return a == b ? EmptySet() : Add(Range(a + 1, b), a)
+	return a == b ? Empty() : Add(Range(a + 1, b), a)
 }
 
 // Constructs a set with all integers in the range [0, n).

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -5,9 +5,16 @@ package sets
 // SO Not taken from outside sources
 // S1 https://github.com/dafny-lang/libraries/blob/master/src/Collections/Sets/Sets.dfy
 // S2 https://github.com/verus-lang/verus/blob/main/source/pervasive/set_lib.rs
+// S3 https://why3.lri.fr/stdlib/set.html
+
 
 // TODO Restructure, rename and properly document definitions at the end
 // (in particular consistency in names of functions, arguments, variables)
+
+// QUES How will set literals be interpreted if we turn of the axioms?
+
+// TODO Figure out what the Gobra warnings are
+// TODO Unicode comments?
 
 // SO
 // TODO Figure out how to import these from verify.gobra
@@ -42,6 +49,12 @@ decreases
 pure func Singleton(x int) set[int] {
 	return set[int] {x}
 }
+
+// TODO Figure out how to properly formalize empty (see comment about
+// empty from S3 below)
+
+// TODO Figure out how to properly formalize Singleton; probably requires
+// similar considerations as empty
 
 // S0
 // Returns an empty set.
@@ -137,11 +150,11 @@ decreases ys
 pure func UnionSizeLower(xs, ys set[int]) Unit {
 	return IsEmpty(ys) ? Unit{} :
 		let y := choose(ys) in
-		(let yr := ys setminus Singleton(y) in
+		(let yr := Remove(ys, y) in
 		(y in xs ?
-			(let xr := xs setminus Singleton(y) in
-			(let _ := Asserting(xr union yr == xs union ys setminus Singleton(y)) in UnionSizeLower(xr, yr))) :
-			(let _ := Asserting(xs union yr == xs union ys setminus Singleton(y)) in UnionSizeLower(xs, yr))))
+			(let xr := Remove(xs, y) in
+			(let _ := Asserting(xr union yr == Remove(xs union ys, y)) in UnionSizeLower(xr, yr))) :
+			(let _ := Asserting(xs union yr == Remove(xs union ys, y)) in UnionSizeLower(xs, yr))))
 }
 // Proof using non-pure function (TODO delete if above is okay)
 // func LemmaUnionSize(xs, ys set[int]) Unit {
@@ -168,7 +181,7 @@ ensures forall i int :: { i in s } (a <= i && i < b) == i in s
 ensures len(s) == b - a
 decreases b - a
 pure func SetRange(a, b int) (s set[int]) {
-	return a == b ? Empty() : Singleton(a) union SetRange(a + 1, b)
+	return a == b ? Empty() : Add(SetRange(a + 1, b), a)
 }
 
 // S1
@@ -197,6 +210,7 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 // SKIP S2: is_singleton() (including forall like that feels off)
 // SKIP S2: find_unique_{mmaximal, minimal*}() (cannot pass function)
 
+// TODO convert this into a pure function
 // S2
 // Converts a set into a multiset where each element from the set has
 // multiplicity 1 and any other element has multiplicity 0.
@@ -209,7 +223,7 @@ func ToMultiset(s set[int]) (ms mset[int]) {
 		return mset[int] {}
 	} else {
 		ghost x := choose(s)
-		return ((mset[int] {}) union (mset[int] {x})) union ToMultiset(s setminus Singleton(x))
+		return ((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
 	}
 }
 
@@ -242,9 +256,9 @@ ensures len(xs intersection ys) <= len(xs)
 decreases xs
 pure func IntersectSizeUpper(xs, ys set[int]) Unit {
 	return IsEmpty(xs) ? Unit{} :
-		let x := Singleton(choose(xs)) in
-		(let _ := Asserting((xs setminus x) intersection ys == (xs intersection ys) setminus x) in
-		(IntersectSizeUpper(xs setminus x, ys)))
+		let x := choose(xs) in
+		(let _ := Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(IntersectSizeUpper(Remove(xs, x), ys)))
 
 }
 // Proof using non-pure function (TODO delete if above is okay)
@@ -344,3 +358,230 @@ pure func SetminusSize(xs, ys set[int]) Unit {
 // SKIP: S2: axiom_is_empty (seems to be more or less choose)
 // SKIP: S2: check_argument_is_set<A> (seems to be specific to Verus)
 // SKIP: S2: Macros (seems to be specific to Verus)
+
+// SKIP S3: Potentially infinite sets (no support in Gobra)
+
+// S3: Finite sets
+// ***************
+// SKIP S3: type fset 'a, meta "material_type_arg" type fset, 0
+// (don't seem to apply to Gobra)
+
+// SKIP S3: mem (built-in `in`)
+// SKIP S3: (==) (built-in `==`)
+// SKIP S3: extensionality (don't seem to apply to Gobra)
+// SKIP S3: subset (seems to be quantified axiom)
+
+// S3
+// Definition of subset without quantifiers.
+ghost
+requires e in xs
+requires xs subset ys
+ensures e in ys
+decreases
+pure func Subset(xs, ys set[int], e int) Unit {
+	return Unit{}
+}
+
+// S3
+// Subset relation is reflexive.
+ghost
+ensures xs subset xs
+decreases
+pure func SubsetReflexive(xs set[int]) Unit {
+	return Unit{}
+}
+
+// S3
+// Subset relation is transitive.
+ghost
+requires xs subset ys
+requires ys subset zs
+ensures xs subset zs
+decreases
+pure func SubsetTransitive(xs, ys, zs set[int]) Unit {
+	return Unit{}
+}
+
+// SKIP: S3 is_empty, empty, is_empty_empty, empty_is_empty
+// unsure how to formalize the empty set: Is it defined as {}, a set of len 0,
+// or as a set s such that forall e . e not in s?
+
+
+// TODO Can we write functions like Add, Remove, etc. (and some above) as Go
+// methods?
+// S3 (add, add_def)
+// Add an element x to the set xs.
+ghost
+// Need this post-condition to verify CardinalAdd
+ensures (x in xs) ==> res == xs
+decreases
+pure func Add(xs set[int], x int) (res set[int]) {
+	return xs union Singleton(x)
+}
+// QUES add_def has mem y (add x s) <-> (mem y s \/ y = x) as its definition
+// We push the work to union; (how) do we need to formalize it?
+
+// SKIP S3: singleton <- already define it as literal in Singleton (S0)
+// SKIP S3: mem_singleton: contains quantifiers; unsure how to formalize singletons:
+// as set of length one? forall x, y. y in Singleton(x) => x = y (S3)?
+// forall x, y: x in Singleton(_) && y in Singleton(_) => x == y (S1, S2)?
+
+// S3
+// Remove the element x from the set xs.
+// TODO Should we add something like ensures !(x in xs) ==> xs == Remove(xs, x)
+// like we did for Add?
+ghost
+decreases
+pure func Remove(xs set[int], x int) set[int] {
+	return xs setminus Singleton(x)
+}
+// QUES remove_def has mem y (remove x s) <-> (mem y s /\ y <> x) as its definition
+// We push the work to setminux; (how) do we need to formalize it?
+
+// S3
+// If x is in the set xs, removing and adding it back in does not change the set
+ghost
+requires x in xs
+ensures Add(Remove(xs, x), x) == xs
+decreases
+pure func AddRemove(xs set[int], x int) Unit {
+	return Unit{}
+}
+
+// S3
+// If we remove x from the set xs, it doesn't matter whether we have added x
+// to it before.
+ghost
+ensures Remove(Add(xs, x), x) == Remove(xs, x)
+decreases
+pure func RemoveAdd(xs set[int], x int) Unit {
+	return Unit{}
+}
+
+// S3
+ghost
+ensures Remove(xs, x) subset xs
+decreases
+pure func SubsetRemove(xs set[int], x int) Unit {
+	return Unit{}
+}
+
+// SKIP S3: union (union is already a "symbol" in Gobra)
+// SKIP S3 union_def (quantified defintion of union)
+// TODO Should we merge SubsetUnion1 and SubsetUnion2?
+// S3
+ghost
+ensures xs subset (xs union ys)
+decreases
+pure func SubsetUnion1(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S3
+ghost
+ensures ys subset (xs union ys)
+decreases
+pure func SubsetUnion2(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// SKIP S3: inter (intersection is already a "symbol" in Gobra)
+// SKIP S3: inter_def (quantified definition of intersection)
+
+// S3
+ghost
+ensures (xs intersection ys) subset xs
+decreases
+pure func SubsetIntersection1(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// S3
+ghost
+ensures (xs intersection ys) subset ys
+decreases
+pure func SubsetIntersection2(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+
+// SKIP S3: diff (setminus is already a "symbol" in Gobra)
+// SKIP S3: diff_def (quantified definition of setminus)
+
+// S3
+ghost
+ensures (xs setminus ys) subset xs 
+decreases
+pure func SubsetSetminus(xs, ys set[int]) Unit {
+	return Unit{}
+}
+
+// SKIP S3: pick, pick_def (corresponds to Choose)
+// SKIP S3: disjoint, disjoint_inter_empty, disjoint_diff_eq,
+// disjoint_diff_s2: definition of disjoint requires a quantifier
+// TODO Notion of disjoint seems useful; (how) should we implement it?
+
+// SKIP S3 filter, filter_def, subset_filter, map, map_def, mem_map (cannot pass functions)
+
+// S3
+ghost
+ensures len(xs) >= 0
+decreases
+pure func CardinalNonneg(xs set[int]) Unit {
+	return Unit{}
+}
+
+// S3 SKIP: cardinal_empty: What does it mean for a set to be empty? (see above)
+
+// S3
+ghost
+ensures (x in xs) ==> (len(Add(xs, x)) == len(xs))
+ensures !(x in xs) ==> (len(Add(xs, x)) == len(xs) + 1)
+decreases
+func CardinalAdd(xs set[int], x int) Unit {
+	return Unit{}
+}
+
+// S3
+ghost
+ensures (x in xs) ==> (len(Remove(xs, x)) == len(xs) - 1)
+ensures !(x in xs) ==> (len(Remove(xs, x)) == len(xs))
+decreases
+func CardinalRemove(xs set[int], x int) Unit {
+	return Unit{}
+}
+
+// SKIP S3 cardinal_subset => corresponds to S1 SubsetSize
+// SKIP S3 subset_eq => corresponds to S1 SubsetEquality
+
+// S3
+// If xs is a Singleton, and x is in xs, then choose(xs) will always return x.
+ghost
+requires len(xs) == 1
+ensures x in xs ==> choose(xs) == x
+decreases
+pure func Cardinal1(xs set[int], x int) Unit {
+	return Unit{}
+}
+
+// SKIP S3 cardinal_union => corresponds to S2 UnionSizeEq
+// SKIP S3 cardinal_inter_disjoint (no notion of disjoint in gobra)
+// SKIP S3 cardinal_diff => included in S2 SetminusSize
+// SKIP S3 cardinal_filter, cardinal_map (cannot pass functions)
+
+// SKIP S3: Induction principle on finite sets
+
+// SKIP S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
+// their post-condition; not sure whether we want such a function
+
+// SKIP S3: interval, interval_def, cardinal_interval => correspond to SetRange
+
+// SKIP Sum of a function over a finite set => cannot pass functions
+
+// S3 The sections in "Finite Monomorphic sets" suggest to move cardinality properties as a
+// postcondition to functions that "generate" it
+// Empty() would return an empty list, but also ensure that its cardinality is 0
+// Add(xs, x) would return a set where x has been added to xs, but also ensure that
+// the cardinality stays the same if x was already in xs, or increases if it wasnt
+// A similar consideration is made for Singleton(x) and Remove(xs, x)
+// TODO Consider whether we want to merge functions like this

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -30,29 +30,6 @@ ensures false
 decreases _
 func TODO()
 
-// SKIP S1: LemmaSubset<T>; implemented below as Subset from S3
-
-// S4: in_empty_set => InEmpty
-// S4: empty_set_cardinality: (Set_card(s) == 0 <==> s == Set_empty()) is
-// expressed by EmptySet and EmptyIsEmptySet. (Set_card(s) != 0 ==> exists e: E :: {Set_in(e, s)} Set_in(e, s))
-// is expressed by choose.
-// S4: in_singleton_set: expressed by SingletonSet
-// S4: in_singleton_set_equality: expressed by SingletonEquality
-// S4: singleton_set_cardinality: expressed by IsSingleton
-// S4: in_unionone_same: expressed by Add
-// S4: in_unionone_other: expressed by InAddOther
-// S4: invariance_in_unionone: expressed by InvarianceInAdd
-// S4: unionone_cardinality_invariant + unionone_cardinality_changed: expressed by CardinalAdd
-// S4: in_union_in_one: expressed by InUnionInOne
-// S4: in_left_in_union/in_right_in_union seems to be a case distinction of InUnionInOne, hence skipped
-// S4: disjoint_sets_difference_union: commented; what are a and b supposed to be?
-// S4: union_left_idempotency/union_right_idempotency -> same name
-// S4: intersection_left_idempotency/intersection_right_idempotency -> same name
-// S4: cardinality_sums -> UnionSizeEq
-// S4: subset_definition -> Subset()
-// S4: equality_definition/native_equality -> SetEquality
-// S4: disjointness_definition: Defined disjointness in terms of intersection instead of more quantifiers
-// S4: cardinality_difference -> SetminusSize
 
 // S4
 ghost
@@ -236,16 +213,6 @@ pure func SingletonSize(x set[int], e int) Unit {
 // 	return Unit{}
 // }
 
-// SKIP S1: IsSingleton: Captured by choose and SingletonEquality
-// SKIP S1: LemmaIsSingleton: This our IsSingleton
-// -> IsSingleton + LemmaIsSingleton is reduced to len(x) == 1 in our implementation.
-// NOTE S1: ExtractFromNonEmptySet and S1: ExtractFromSingleton are in choose
-
-// SKIP S1: MapSize<> (no Injective() defined)
-// SKIP S1: Map<> (no Injective() defined)
-// SKIP S1: LemmaFilterSize<> (not sure whether ~>/passing functions exists in Gobra)
-// SKIP S1: Filter (not sure whether ~>/passing functions exists in Gobra)
-
 // S1
 // The size of a union of two sets is greater than or equal to the size of
 // either individual set.
@@ -289,18 +256,6 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 // TODO Do we want S1: LemmaBoundedSetSize? (Dafny proof requires LemmaSubsetSize +
 // contains unclear forall in proof)
 
-// SKIP S1: LemmaGreatestImplies{Minimal, Maximal}, LemmaMaximalEquivalentGreatest
-// LemmaMinimalEquivalentLeast, LeammLeastIsUnique, LemmaGreatestIsUnique, LemmaMinimalIsUnique
-// LemmaMaximalIsUnique, LemmaFindUniqueMinimal, LemmaFindUniqueMaximal
-// since Orderings are not defined
-
-// SKIP S2: is_full (don't have a notion of full)
-// SKIP S2: map<B>, fold<E> (cannot pass functions)
-// SKIP S2: to_seq() (probably not worth the quantifiers)
-// SKIP S2: to_sorted_seq() (cannot pass function)
-// SKIP S2: is_singleton() -> formalized above
-// SKIP S2: find_unique_{mmaximal, minimal*}() (cannot pass function)
-
 // TODO: Do we even want to bother with multisets?
 // S2
 // Converts a set into a multiset where each element from the set has
@@ -315,14 +270,6 @@ pure func SetRangeFromZero(n int) (s set[int]) {
 // 		((mset[int] {}) union (mset[int] {x})) union ToMultiset(Remove(s, x))
 // }
 
-// SKIP: S2: lemma_len0_is_empty(self) <- this one is confusing, since we defined IsEmpty before
-// SKIP: S2: lemma_singleton_size + lemma_is_singleton
-// => formalized empty and singleton sets above
-
-// SKIP: S2: lemma_len_filter, lemma_greatest_implies_maximal, lemma_least_implies_minimal,
-// lemma_maximal_equivalent_greatest, lemma_minimal_equivalent_least, lemma_least_is_unique,
-// lemma_greatest_is_unique, lemma_minimal_is_unique, lemma_maximal_is_unique (cannot pass functions/no ordering)
-
 // S2
 // The size of a union of two sets is less than or equal to the size of
 // both individual sets combined.
@@ -332,8 +279,6 @@ decreases
 pure func UnionSizeUpper(xs, ys set[int]) Unit {
 	return Unit{}
 }
-
-// SKIP: S2: lemma_len_union_ind (corresponds to UnionSizeLower from S1)
 
 // S2
 // The size of the intersection of xs and ys is less than or equal to the
@@ -349,7 +294,6 @@ pure func IntersectSizeUpper(xs, ys set[int]) Unit {
 
 }
 
-// SKIP: S2 lemma_len_subset corresponds to SubsetSize from S1
 
 // S2
 // The size of the difference xs - ys is less than or equal to the size of xs. 
@@ -359,11 +303,6 @@ decreases
 pure func SetminusSizeUpper(xs, ys set[int]) Unit {
 	return Unit{}
 }
-
-// SKIP: S2: set_int_range, lemma_int_range correspond to SetRange from S1
-// SKIP: S2: lemma_subset_equality corresponds to SubsetEquality from S1
-
-// SKIP: S2: lemma_map_size (cannot pass function)
 
 ghost
 ensures (xs union ys) == (ys union xs)
@@ -440,9 +379,6 @@ pure func SetDisjoint(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-// SKIP S2: lemma_set_empty_equivalency_len (unclear how it ties to the rest,
-// since we already consider IsEmpty() and Choose())
-
 ghost
 requires AreDisjoint(xs, ys)
 ensures len(xs union ys) == len(xs) + len(ys)
@@ -468,22 +404,9 @@ pure func SetminusSize(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-// SKIP: S2: axiom_is_empty (seems to be more or less choose)
-// SKIP: S2: check_argument_is_set<A> (seems to be specific to Verus)
-// SKIP: S2: Macros (seems to be specific to Verus)
-
-// SKIP S3: Potentially infinite sets (no support in Gobra)
 
 // S3: Finite sets
 // ***************
-// SKIP S3: type fset 'a, meta "material_type_arg" type fset, 0
-// (don't seem to apply to Gobra)
-
-// SKIP S3: mem (built-in `in`)
-// SKIP S3: (==) (built-in `==`)
-// SKIP S3: extensionality (doesn't seem to apply to Gobra)
-// SKIP S3: subset (seems to be quantified axiom)
-
 // S3
 // Definition of subset without quantifiers.
 ghost
@@ -525,8 +448,6 @@ decreases
 pure func Add(xs set[int], x int) (res set[int]) {
 	return xs union SingletonSet(x)
 }
-
-// SKIP S3: singleton, mem_singleton -> formalized above
 
 // S4
 ghost
@@ -583,8 +504,6 @@ pure func SubsetRemove(xs set[int], x int) Unit {
 	return Unit{}
 }
 
-// SKIP S3: union (union is already a "symbol" in Gobra)
-// SKIP S3 union_def (quantified defintion of union)
 
 // TODO Should we merge SubsetUnion1 and SubsetUnion2?
 // S3
@@ -603,9 +522,6 @@ pure func SubsetUnion2(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-// SKIP S3: inter (intersection is already a "symbol" in Gobra)
-// SKIP S3: inter_def (quantified definition of intersection)
-
 // S3
 ghost
 ensures (xs intersection ys) subset xs
@@ -622,10 +538,6 @@ pure func SubsetIntersection2(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-
-// SKIP S3: diff (setminus is already a "symbol" in Gobra)
-// SKIP S3: diff_def (quantified definition of setminus)
-
 // S3
 ghost
 ensures (xs setminus ys) subset xs 
@@ -634,11 +546,6 @@ pure func SubsetSetminus(xs, ys set[int]) Unit {
 	return Unit{}
 }
 
-// SKIP S3: pick, pick_def (corresponds to Choose)
-// SKIP S3: disjoint, disjoint_inter_empty, disjoint_diff_eq,
-// disjoint_diff_s2: implemented above
-
-// SKIP S3 filter, filter_def, subset_filter, map, map_def, mem_map (cannot pass functions)
 
 // S3
 ghost
@@ -666,10 +573,6 @@ decreases
 func CardinalRemove(xs set[int], x int) Unit {
 	return Unit{}
 }
-
-// SKIP S3 cardinal_subset => corresponds to S1 SubsetSize
-// SKIP S3 subset_eq => corresponds to S1 SubsetEquality
-
 // S3
 // If xs is a Singleton, and x is in xs, then choose(xs) will always return x.
 ghost
@@ -680,19 +583,9 @@ pure func Cardinal1(xs set[int], x int) Unit {
 	return Unit{}
 }
 
-// SKIP S3 cardinal_union => corresponds to S2 UnionSizeEq
-// SKIP S3 cardinal_inter_disjoint => follows from definition of disjoint
-// SKIP S3 cardinal_diff => included in S2 SetminusSize
-// SKIP S3 cardinal_filter, cardinal_map (cannot pass functions)
+// TODO S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
+// their post-condition; do we want these functions?
 
-// SKIP S3: Induction principle on finite sets
-
-// SKIP S3: min_elt{,_def}, max_elt{,_def} mention forall x . x in xs in
-// their post-condition; not sure whether we want such a function
-
-// SKIP S3: interval, interval_def, cardinal_interval => correspond to SetRange
-
-// SKIP Sum of a function over a finite set => cannot pass functions
 
 // S3 The sections in "Finite Monomorphic sets" suggest to move cardinality properties as a
 // postcondition to functions that "generate" it
@@ -700,4 +593,4 @@ pure func Cardinal1(xs set[int], x int) Unit {
 // Add(xs, x) would return a set where x has been added to xs, but also ensure that
 // the cardinality stays the same if x was already in xs, or increases if it wasnt
 // A similar consideration is made for Singleton(x) and Remove(xs, x)
-// TODO Consider whether we want to merge functions like this
+// TODO Do we want to merge functions like this?

--- a/utils/verify.gobra
+++ b/utils/verify.gobra
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gobra
+package util
 
 type Unit struct{}
 


### PR DESCRIPTION
Set in sets.EmptySet() is redundant; additionally, it will be more consistent with the package for sequences (i.e., seqs.Empty())