### PR TITLE
Bytes

### DIFF
--- a/bytes/bytes.gobra
+++ b/bytes/bytes.gobra
@@ -22,12 +22,8 @@ requires 0 < len(sep)
 decreases len(s)
 pure func SplitInner(s, sep, ac seq[byte]) (res seq[seq[byte]]) {
 	return len(s) == 0 ?
-		( len(ac) == 0 ?
-			seq[seq[byte]]{} :
-			seq[seq[byte]]{ac}) :
-		( sep == s ?
-			seq[seq[byte]]{ ac, seq[byte]{} } :
-			s[:len(sep)] == sep ?
-				seq[seq[byte]]{ac} ++ SplitInner(s[len(sep):], sep, seq[byte]{}) :
-				SplitInner(s[1:], sep, ac ++ seq[byte]{s[0]}))
+		seq[seq[byte]]{ac} :
+		s[:len(sep)] == sep ?
+			seq[seq[byte]]{ac} ++ SplitInner(s[len(sep):], sep, seq[byte]{}) :
+			SplitInner(s[1:], sep, ac ++ seq[byte]{s[0]})
 }

--- a/bytes/bytes.gobra
+++ b/bytes/bytes.gobra
@@ -12,6 +12,7 @@ pure func Repeat(b seq[byte], count int) (res seq[byte]) {
 
 ghost
 requires 0 < len(sep)
+ensures 0 < len(res)
 decreases
 pure func Split(b, sep seq[byte]) (res seq[seq[byte]]) {
 	return SplitInner(b, sep, seq[byte]{})
@@ -19,6 +20,7 @@ pure func Split(b, sep seq[byte]) (res seq[seq[byte]]) {
 
 ghost
 requires 0 < len(sep)
+ensures 0 < len(res)
 decreases len(s)
 pure func SplitInner(s, sep, ac seq[byte]) (res seq[seq[byte]]) {
 	return len(s) == 0 ?

--- a/bytes/bytes.gobra
+++ b/bytes/bytes.gobra
@@ -1,3 +1,17 @@
+// Copyright 2024 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //+gobra
 
 package bytes

--- a/bytes/bytes.gobra
+++ b/bytes/bytes.gobra
@@ -1,0 +1,25 @@
+//+gobra
+
+package bytes
+
+ghost
+requires 0 < len(sep)
+decreases
+pure func Split(b, sep seq[byte]) (res seq[seq[byte]]) {
+	return SplitInner(b, sep, seq[byte]{})
+}
+
+ghost
+requires 0 < len(sep)
+decreases len(s)
+pure func SplitInner(s, sep, ac seq[byte]) (res seq[seq[byte]]) {
+	return len(s) == 0 ?
+		( len(ac) == 0 ?
+			seq[seq[byte]]{} :
+			seq[seq[byte]]{ac}) :
+		( sep == s ?
+			seq[seq[byte]]{ ac, seq[byte]{} } :
+			s[:len(sep)] == sep ?
+				seq[seq[byte]]{ac} ++ SplitInner(s[len(sep):], sep, seq[byte]{}) :
+				SplitInner(s[1:], sep, ac ++ seq[byte]{s[0]}))
+}

--- a/bytes/bytes.gobra
+++ b/bytes/bytes.gobra
@@ -2,6 +2,14 @@
 
 package bytes
 
+	
+ghost
+requires count >= 0
+decreases count
+pure func Repeat(b seq[byte], count int) (res seq[byte]) {
+	return count == 0 ? seq[byte]{} : ( b ++ Repeat(b, count - 1) )
+}
+
 ghost
 requires 0 < len(sep)
 decreases

--- a/bytes/bytes.gobra
+++ b/bytes/bytes.gobra
@@ -15,7 +15,6 @@
 //+gobra
 
 package bytes
-
 	
 ghost
 requires count >= 0

--- a/bytes/bytes_test.gobra
+++ b/bytes/bytes_test.gobra
@@ -19,7 +19,7 @@ decreases
 func testSplit() {
 	abcd := seq[byte]{'a','b','c','d'}
 
-	// this block of assertions is simply to teach gobra how to unfold the definition of `SplitInner`
+	// these assertions force Gobra to expand the definition of `SplitInner`
 	assert SplitInner(seq[byte]{}, seq[byte]{'a'}, seq[byte]{'b', 'c', 'd'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
 	assert seq[byte]{'d'}[1:] == seq[byte]{}
 	assert SplitInner(seq[byte]{'d'}, seq[byte]{'a'}, seq[byte]{'b', 'c'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}

--- a/bytes/bytes_test.gobra
+++ b/bytes/bytes_test.gobra
@@ -21,6 +21,36 @@ func testSplit() {
 
 ghost
 decreases
+func testSplitEnd() {
+	abcd := seq[byte]{'a','b','c','d'}
+	abc := seq[byte]{'a','b','c'}
+	sep := seq[byte]{'d'}
+
+	assert SplitInner(seq[byte]{}, sep, seq[byte]{}) == seq[seq[byte]]{seq[byte]{}}
+	assert sep[1:] == seq[byte]{}
+	assert SplitInner(sep, sep, abc) == seq[seq[byte]]{abc, seq[byte]{}}
+	assert seq[byte]{'c', 'd'}[1:] == sep
+	assert SplitInner(seq[byte]{'c', 'd'}, sep, seq[byte]{'a', 'b'}) == seq[seq[byte]]{abc, seq[byte]{}}
+	assert seq[byte]{'b', 'c', 'd'}[1:] == seq[byte]{'c', 'd'}
+	assert SplitInner(seq[byte]{'b', 'c', 'd'}, sep, seq[byte]{'a'}) == seq[seq[byte]]{abc, seq[byte]{}}
+	assert abcd[1:] == seq[byte]{'b', 'c', 'd'}
+	assert SplitInner(abcd, sep, seq[byte]{}) == seq[seq[byte]]{abc, seq[byte]{}}
+	assert Split(abcd, sep) == seq[seq[byte]]{abc, seq[byte]{}}
+
+	assert Split(abcd, seq[byte]{'d'}) == seq[seq[byte]]{ seq[byte]{'a','b','c'}, seq[byte]{} }
+}
+
+ghost
+decreases
+func testSplitEmpty() {
+	sep := seq[byte]{'/'}
+	
+	assert SplitInner(seq[byte]{}, sep, seq[byte]{}) == seq[seq[byte]]{seq[byte]{}}
+	assert Split(seq[byte]{}, sep) == seq[seq[byte]]{seq[byte]{}}
+}
+
+ghost
+decreases
 func testRepeat() {
 	assert Repeat(seq[byte]{'a', 'b'}, 0) == seq[byte]{}
 	assert Repeat(seq[byte]{'a', 'b'}, 1) == seq[byte]{'a', 'b'}

--- a/bytes/bytes_test.gobra
+++ b/bytes/bytes_test.gobra
@@ -1,0 +1,19 @@
+package bytes
+
+ghost
+decreases
+func testSplit() {
+	abcd := seq[byte]{'a','b','c','d'}
+
+	assert SplitInner(seq[byte]{}, seq[byte]{'a'}, seq[byte]{'b', 'c', 'd'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
+	assert seq[byte]{'d'}[1:] == seq[byte]{}
+	assert SplitInner(seq[byte]{'d'}, seq[byte]{'a'}, seq[byte]{'b', 'c'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
+	assert seq[byte]{'c', 'd'}[1:] == seq[byte]{'d'}
+	assert SplitInner(seq[byte]{'c', 'd'}, seq[byte]{'a'}, seq[byte]{'b'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
+	assert seq[byte]{'b', 'c', 'd'}[1:] == seq[byte]{'c', 'd'}
+	assert SplitInner(seq[byte]{'b', 'c', 'd'}, seq[byte]{'a'}, seq[byte]{}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
+	assert seq[byte]{'a', 'b', 'c', 'd'}[1:] == seq[byte]{'b', 'c', 'd'}
+	assert SplitInner(seq[byte]{'a', 'b', 'c', 'd'}, seq[byte]{'a'}, seq[byte]{}) == seq[seq[byte]]{seq[byte]{}, seq[byte]{'b', 'c', 'd'}}
+
+	assert Split(abcd, seq[byte]{'a'}) == seq[seq[byte]]{ seq[byte]{}, seq[byte]{'b','c','d'} }
+}

--- a/bytes/bytes_test.gobra
+++ b/bytes/bytes_test.gobra
@@ -5,6 +5,7 @@ decreases
 func testSplit() {
 	abcd := seq[byte]{'a','b','c','d'}
 
+	// this block of assertions is simply to teach gobra how to unfold the definition of `SplitInner`
 	assert SplitInner(seq[byte]{}, seq[byte]{'a'}, seq[byte]{'b', 'c', 'd'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
 	assert seq[byte]{'d'}[1:] == seq[byte]{}
 	assert SplitInner(seq[byte]{'d'}, seq[byte]{'a'}, seq[byte]{'b', 'c'}) == seq[seq[byte]]{seq[byte]{'b', 'c', 'd'}}
@@ -16,4 +17,13 @@ func testSplit() {
 	assert SplitInner(seq[byte]{'a', 'b', 'c', 'd'}, seq[byte]{'a'}, seq[byte]{}) == seq[seq[byte]]{seq[byte]{}, seq[byte]{'b', 'c', 'd'}}
 
 	assert Split(abcd, seq[byte]{'a'}) == seq[seq[byte]]{ seq[byte]{}, seq[byte]{'b','c','d'} }
+}
+
+ghost
+decreases
+func testRepeat() {
+	assert Repeat(seq[byte]{'a', 'b'}, 0) == seq[byte]{}
+	assert Repeat(seq[byte]{'a', 'b'}, 1) == seq[byte]{'a', 'b'}
+
+	assert Repeat(seq[byte]{'a', 'b'}, 2) == seq[byte]{'a', 'b', 'a', 'b'}
 }

--- a/bytes/bytes_test.gobra
+++ b/bytes/bytes_test.gobra
@@ -1,3 +1,17 @@
+// Copyright 2024 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bytes
 
 ghost

--- a/byteslice/byteslice.gobra
+++ b/byteslice/byteslice.gobra
@@ -41,7 +41,7 @@ ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
 decreases
 opaque
 pure func View(ub []byte) (res seq[byte]) {
-	return unfolding acc(Bytes(ub, 0, len(ub)), _) in viewInner(ub)
+	return unfolding acc(Bytes(ub, 0, len(ub)), _) in ViewInner(ub)
 }
 
 ghost
@@ -49,8 +49,8 @@ requires forall i int :: {&ub[i]} 0 <= i && i < len(ub) ==> acc(&ub[i], _)
 ensures  len(res) == len(ub)
 ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==> res[i] == ub[i]
 decreases len(ub)
-pure func viewInner(ub []byte) (res seq[byte]) {
-	return len(ub) == 0 ? seq[byte]{} :  viewInner(ub[:len(ub)-1]) ++ seq[byte]{ub[len(ub)-1]}
+pure func ViewInner(ub []byte) (res seq[byte]) {
+	return len(ub) == 0 ? seq[byte]{} :  ViewInner(ub[:len(ub)-1]) ++ seq[byte]{ub[len(ub)-1]}
 }
 
 ghost

--- a/byteslice/byteslice.gobra
+++ b/byteslice/byteslice.gobra
@@ -35,12 +35,23 @@ func Byte(s []byte, start int, end int, i int) byte {
 
 ghost
 requires acc(Bytes(ub, 0, len(ub)), _)
-ensures len(res) == len(ub)
-ensures forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+ensures  len(res) == len(ub)
+ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
     res[i] == Byte(ub, 0, len(ub), i)
-decreases len(ub)
+decreases
 opaque
-pure func View(ub []byte) (res seq[byte])
+pure func View(ub []byte) (res seq[byte]) {
+	return unfolding acc(Bytes(ub, 0, len(ub)), _) in viewInner(ub)
+}
+
+ghost
+requires forall i int :: {&ub[i]} 0 <= i && i < len(ub) ==> acc(&ub[i], _)
+ensures  len(res) == len(ub)
+ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==> res[i] == ub[i]
+decreases len(ub)
+pure func viewInner(ub []byte) (res seq[byte]) {
+	return len(ub) == 0 ? seq[byte]{} :  viewInner(ub[:len(ub)-1]) ++ seq[byte]{ub[len(ub)-1]}
+}
 
 ghost
 requires 0 < p

--- a/byteslice/byteslice.gobra
+++ b/byteslice/byteslice.gobra
@@ -34,6 +34,15 @@ func Byte(s []byte, start int, end int, i int) byte {
 }
 
 ghost
+requires acc(Bytes(ub, 0, len(ub)), _)
+ensures len(res) == len(ub)
+ensures forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+    res[i] == Byte(ub, 0, len(ub), i)
+decreases len(ub)
+opaque
+pure func View(ub []byte) (res seq[byte])
+
+ghost
 requires 0 < p
 requires acc(Bytes(s, start, end), p)
 requires start <= idx && idx <= end

--- a/byteslice/byteslice.gobra
+++ b/byteslice/byteslice.gobra
@@ -45,7 +45,7 @@ pure func View(ub []byte) (res seq[byte]) {
 }
 
 ghost
-requires forall i int :: {&ub[i]} 0 <= i && i < len(ub) ==> acc(&ub[i], _)
+requires forall i int :: { &ub[i] } 0 <= i && i < len(ub) ==> acc(&ub[i], _)
 ensures  len(res) == len(ub)
 ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==> res[i] == ub[i]
 decreases len(ub)


### PR DESCRIPTION
Introduce a `bytes` package that mirrors go's `bytes` package. Currently supported functions are `Split` and `Repeat`.

Furthermore, a function `View` in `byteslice` is added to map `[]byte -> seq[byte]`. 

For `Split`, we require the separator to be non-empty. The Go implementation handles this case by returning a string split at every utf8 codepoint boundary: `Split("abc☺", "") -> "a", "b", "c", "☺"`
Do we want to mimic this behavior?