### PR TITLE
Fix type errors caused by recent changes to Gobra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ go.work
 *.vpr
 *.log
 *.smt2
+
+# Evaluation
+evaluation/scripts/__pycache__/*
+evaluation/scripts/output.txt

--- a/evaluation/experiments/program_proofs_example_10_2/first_half/first_half.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/first_half/first_half.gobra
@@ -91,9 +91,9 @@ pure func asserting(b bool) Unit {
 	return Unit{}
 }
 
-type PQueue = BraunTree
+ghost type PQueue = BraunTree
 
-type BraunTree adt {
+ghost type BraunTree adt {
 	Leaf {}
 
 	Node {

--- a/evaluation/experiments/program_proofs_example_10_2/full/full.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/full/full.gobra
@@ -100,9 +100,9 @@ pure func asserting(b bool) Unit {
 	return Unit{}
 }
 
-type PQueue = BraunTree
+ghost type PQueue = BraunTree
 
-type BraunTree adt {
+ghost type BraunTree adt {
 	Leaf {}
 
 	Node {

--- a/evaluation/experiments/program_proofs_example_10_2/last_half/last_half.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/last_half/last_half.gobra
@@ -97,9 +97,9 @@ pure func asserting(b bool) Unit {
 	return Unit{}
 }
 
-type PQueue = BraunTree
+ghost type PQueue = BraunTree
 
-type BraunTree adt {
+ghost type BraunTree adt {
 	Leaf {}
 
 	Node {

--- a/evaluation/experiments/program_proofs_example_10_2/minimal/minimal.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/minimal/minimal.gobra
@@ -84,9 +84,9 @@ pure func asserting(b bool) Unit {
 	return Unit{}
 }
 
-type PQueue = BraunTree
+ghost type PQueue = BraunTree
 
-type BraunTree adt {
+ghost type BraunTree adt {
 	Leaf {}
 
 	Node {

--- a/math/nat.gobra
+++ b/math/nat.gobra
@@ -23,7 +23,7 @@ package math
 // ##(-I ..)
 import . "util"
 
-type Nat adt {
+ghost type Nat adt {
 	Zero{}
 	Succ {
 		pre Nat
@@ -33,7 +33,7 @@ type Nat adt {
 // PairNat is a pair of Nats. This is a useful structure
 // for doing simultaneous pattern match on two Nats.
 // TODO: use generic pairs when gobra supports generics.
-type PairNat adt {
+ghost type PairNat adt {
 	PairNatC {
 		Fst Nat
 		Snd Nat


### PR DESCRIPTION
The recent addition of ghost types and the corresponding changes in the type checker caused new type errors to be reported on the previously verified code in this repo. This PR addresses these changes and restores the repo to working condition.