### PR TITLE
resalgebraNoAxioms: Verify global validity of ghost locations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "gobra-libs dev container",
+  "image": "ghcr.io/viperproject/gobra:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {}
+  }
+}

--- a/.github/workflows/gobra.yml
+++ b/.github/workflows/gobra.yml
@@ -32,7 +32,9 @@ jobs:
         with:
           projectLocation: 'gobra-libs'
           recursive: 1
-          timeout: 5m
+          # disabled for now, due to the long verification times for the resource-algebras
+          # formalization.
+          # timeout: 5m
           includePaths: '.' # relative to project location
           assumeInjectivityOnInhale: ${{ env.assumeInjectivityOnInhale }}
           checkConsistency: ${{ env.checkConsistency }}

--- a/resalgebraNoAxioms/loc.gobra
+++ b/resalgebraNoAxioms/loc.gobra
@@ -132,8 +132,10 @@ pure func LiftedIsValid(ra RA, e option[Elem]) bool {
 /***** Model: Global State *****/
 
 pred GlobalMem() {
-	inv(model) &&
-	ras.Inv()  &&
+	inv(model)        &&
+	ras.Inv()         &&
+	acc(&inUseIdx)    &&
+	acc(&inUseVal)    &&
 	// necessary for proving key freshness
 	(forall k LocName :: { k elem domain(toDict(model)) } k elem domain(toDict(model)) ==> acc(k, 1/2)) &&
 	// complicated way of saying that the domains of model and ras are the same:
@@ -160,15 +162,84 @@ pred GlobalMem() {
 			i.inUse ==> (
 				forall i2 idx :: { ras.ToDict()[k].Compose(i.val, i2.val) } i2 elem toCoolSet(toDict(model)[k]) && i2.inUse && i2 !== i ==>
 					ras.ToDict()[k].IsElem(ras.ToDict()[k].Compose(i.val, i2.val)) &&
-					ras.ToDict()[k].IsValid(ras.ToDict()[k].Compose(i.val, i2.val)))))
-	// MISSING: the product of all inUse elements is valid. requires proving all kinds of facts
-	//          about the updates to the set of values inUse and the order in which the multiplication is performed.
-	//          this is easy to show ghostOp1 and ghostOp2 and frame-preserving updates
+					ras.ToDict()[k].IsValid(ras.ToDict()[k].Compose(i.val, i2.val))))) &&
+	// In-use value tracking: per-location seqs of currently-in-use idx pointers and their
+	// values. Foundation for the product-of-in-use-values invariant.
+	domain(toDict(model)) subset domain(inUseIdx) &&
+	domain(toDict(model)) subset domain(inUseVal) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		len(getIdxAt(k)) >= 1) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		len(getValAt(k)) >= 1) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		len(getIdxAt(k)) == len(getValAt(k))) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		(forall i idx :: i elem toCoolSet(toDict(model)[k]) && i.inUse ==>
+			i elem getIdxAt(k))) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		(forall j int :: 0 <= j && j < len(getIdxAt(k)) ==>
+			getIdxAt(k)[j] elem toCoolSet(toDict(model)[k]))) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		(forall j1, j2 int :: 0 <= j1 && j1 < j2 && j2 < len(getIdxAt(k)) ==>
+			getIdxAt(k)[j1] !== getIdxAt(k)[j2])) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		(forall j int :: 0 <= j && j < len(getIdxAt(k)) ==>
+			getIdxAt(k)[j].val === getValAt(k)[j])) &&
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		(forall j int :: 0 <= j && j < len(getValAt(k)) ==>
+			ras.ToDict()[k].IsElem(getValAt(k)[j]))) &&
+	// Product validity: the composition of all in-use values at k is valid under ras[k].
+	(forall k LocName :: k elem domain(toDict(model)) ==>
+		ras.ToDict()[k].IsValid(ProductOfSeq(getValAt(k), ras.ToDict()[k])))
+}
+
+// Helper accessors returning a single seq for a given key (force single-typed lookup).
+ghost
+requires acc(&inUseIdx, _)
+decreases
+pure func getIdxAt(k LocName) seq[idx] {
+	return idxSeqLookup(inUseIdx, k)
+}
+
+ghost
+requires acc(&inUseVal, _)
+decreases
+pure func getValAt(k LocName) seq[Elem] {
+	return valSeqLookup(inUseVal, k)
+}
+
+ghost
+decreases
+pure func idxSeqLookup(d dict[LocName](seq[idx]), k LocName) seq[idx] {
+	return k elem domain(d) ? d[k] : seq[idx]{}
+}
+
+ghost
+decreases
+pure func valSeqLookup(d dict[LocName](seq[Elem]), k LocName) seq[Elem] {
+	return k elem domain(d) ? d[k] : seq[Elem]{}
+}
+
+// Find the (first) position of x in s. Requires x to be present in s.
+ghost
+requires len(s) >= 1
+requires x elem s
+ensures  0 <= res && res < len(s)
+ensures  s[res] === x
+decreases len(s)
+pure func idxPos(s seq[idx], x idx) (res int) {
+	return (s[0] === x) ? 0 : 1 + idxPos(s[1:], x)
 }
 
 // TODO: use MonoSet and MonoMap for the model; delete cooliosetio and mapio
 ghost var model cooliomapio = allocMap()
 ghost var ras rasMap = rasMapAlloc()
+
+// Per-location sequences of currently-in-use idx pointers and their values.
+// Maintained in lockstep with the in-use indices in `model`. These are used
+// by `GlobalMem()` to state the product-of-all-in-use-values invariant.
+ghost var inUseIdx@ dict[LocName](seq[idx])
+ghost var inUseVal@ dict[LocName](seq[Elem])
 
 func init() {
 	fold GlobalMem()
@@ -245,6 +316,9 @@ func AllocWI(ra RA, e Elem) (l LocName, w Witness) {
 	assert forall k LocName :: k elem domain(toDict(model)) ==>
 		(forall i idx :: i elem toCoolSet(toDict(model)[k]) ==>
 			i.inUse ==> (ras.ToDict()[k].IsElem(i.val) && ras.ToDict()[k].IsValid(i.val)))
+
+	inUseIdx[newl] = seq[idx]{iii}
+	inUseVal[newl] = seq[Elem]{e}
 	fold GlobalMem()
 
 	return newl, newi
@@ -316,6 +390,17 @@ func GhostOp1WI(l LocName, ra RA, e1 Elem, e2 Elem, w Witness) (w1 Witness, w2 W
 					ras.ToDict()[k].IsElem(ras.ToDict()[k].Compose(i.val, i2.val)) &&
 					ras.ToDict()[k].IsValid(ras.ToDict()[k].Compose(i.val, i2.val))))
 
+	// Replace i.i's slot in the seqs with iii1 (val e1) and append iii2 (val e2).
+	// i.i is no longer in-use, but by the completeness invariant it was in getIdxAt(l) while still in-use.
+	posI := idxPos(getIdxAt(l), i.i)
+	oldVals := getValAt(l)
+	pre := oldVals[:posI]
+	post := oldVals[posI+1:]
+	assert oldVals[posI] === ra.Compose(e1, e2)
+	assert oldVals === pre ++ seq[Elem]{ra.Compose(e1, e2)} ++ post
+	ProductSplitEq(pre, post, e1, e2, ra)
+	inUseIdx[l] = getIdxAt(l)[:posI] ++ seq[idx]{iii1} ++ getIdxAt(l)[posI+1:] ++ seq[idx]{iii2}
+	inUseVal[l] = pre ++ seq[Elem]{e1} ++ post ++ seq[Elem]{e2}
 	fold GlobalMem()
 	return i1, i2
 }
@@ -415,10 +500,30 @@ func GhostOp2WI(l LocName, ra RA, e1 Elem, e2 Elem, w1 Witness, w2 Witness) {
 	assert ra.IsElem(ra.Compose(i1.i.val, i2.i.val))
 	assert ra.IsValid(ra.Compose(i1.i.val, i2.i.val))
 
-	// TODO: this is where the invariant of Validity of the product of all elements comes in handy
-	//       to prove this assumption
-	assume forall ii idx :: ii elem toCoolSet(toDict(model)[l]) && ii.inUse && ii !== i1.i && ii != i2.i ==>
-		// let _ := ghostOp2WIaux(ra, e1, e2, ii.val) in
+	// Capture seq positions and values BEFORE mutating i1.i.val or i2.i.inUse.
+	posI1 := idxPos(getIdxAt(l), i1.i)
+	posI2 := idxPos(getIdxAt(l), i2.i)
+	pmin, pmax := posI1, posI2
+	if posI1 > posI2 {
+		pmin, pmax = posI2, posI1
+	}
+	oldVals := getValAt(l)
+	oldIdxs := getIdxAt(l)
+	assert oldVals[posI1] === e1
+	assert oldVals[posI2] === e2
+	ProductMergeAt(oldVals, posI1, posI2, ra)
+	// ProductMergeAt yields IsValid of the merged seq:
+	//   oldVals[:pmin] ++ [Compose(e1,e2)] ++ oldVals[pmin+1:pmax] ++ oldVals[pmax+1:]
+
+	// Discharge: derive `IsValid(Compose(Compose(e1, e2), ii.val))` for any other in-use ii at l.
+	// By completeness, every in-use i at l appears in inUseIdx[l] (= oldIdxs).
+	// By distinctness, the positions of i1.i, i2.i, and any third ii are all distinct.
+	// By IsElem invariant on values, all entries of oldVals are RA elements.
+	// By the product-validity invariant, ProductOfSeq(oldVals, ra) is valid, so by
+	// `ExtractThreeValid` (pure, in product.gobra) any triple of values has its triple-Compose valid.
+	assert forall ii idx :: ii elem toCoolSet(toDict(model)[l]) && ii.inUse && ii !== i1.i && ii != i2.i ==>
+		let posIi := idxPos(oldIdxs, ii) in
+		let _ := ExtractThreeValid(oldVals, ra, posI1, posI2, posIi) in
 		ras.ToDict()[l].IsElem(ras.ToDict()[l].Compose(ra.Compose(e1, e2), ii.val)) &&
 		ras.ToDict()[l].IsValid(ras.ToDict()[l].Compose(ra.Compose(e1, e2), ii.val))
 
@@ -438,6 +543,10 @@ func GhostOp2WI(l LocName, ra RA, e1 Elem, e2 Elem, w1 Witness, w2 Witness) {
 		let _ := ra.ComposeComm(i2.val, i1.i.val) in
 		ras.ToDict()[l].IsElem(ras.ToDict()[l].Compose(i2.val, i1.i.val)) &&
 		ras.ToDict()[l].IsValid(ras.ToDict()[l].Compose(i2.val, i1.i.val))
+
+	inUseVal[l] = oldVals[:pmin] ++ seq[Elem]{ra.Compose(e1, e2)} ++ oldVals[pmin+1:pmax] ++ oldVals[pmax+1:]
+	inUseIdx[l] = oldIdxs[:pmin] ++ seq[idx]{i1.i} ++ oldIdxs[pmin+1:pmax] ++ oldIdxs[pmax+1:]
+
 	fold GlobalMem()
 }
 
@@ -471,6 +580,12 @@ func GhostUpdateWI(l LocName, ra RA, e1 Elem, e2 Elem, w Witness) {
 		ras.ToDict()[l].IsElem(ras.ToDict()[l].Compose(e2, i2.val)) &&
 		ras.ToDict()[l].IsValid(ras.ToDict()[l].Compose(e2, i2.val))
 
+	// Capture seq position and apply product FPU lemma BEFORE mutating i.i.val.
+	posI := idxPos(getIdxAt(l), i.i)
+	oldVals := getValAt(l)
+	assert oldVals[posI] === e1
+	ProductFPUEq(oldVals, posI, e1, e2, ra)
+
 	i.i.val = e2
 
 	if forall e Elem :: ra.IsElem(e) ==> LiftedCompose(ra, some(e1), some(e)) === none[Elem] {
@@ -501,6 +616,9 @@ func GhostUpdateWI(l LocName, ra RA, e1 Elem, e2 Elem, w Witness) {
 		let _ := ra.ComposeComm(i2.val, i.i.val) in
 		ras.ToDict()[l].IsElem(ras.ToDict()[l].Compose(i2.val, i.i.val)) &&
 		ras.ToDict()[l].IsValid(ras.ToDict()[l].Compose(i2.val, i.i.val))
+
+	// Update inUseVal[l] at i.i's position to the new value e2 using the captured oldVals.
+	inUseVal[l] = oldVals[:posI] ++ seq[Elem]{e2} ++ oldVals[posI+1:]
 
 	fold GhostLocationW(l, ra, e2, i)
 	fold GlobalMem()

--- a/resalgebraNoAxioms/loc.gobra
+++ b/resalgebraNoAxioms/loc.gobra
@@ -193,7 +193,7 @@ pred GlobalMem() {
 		ras.ToDict()[k].IsValid(ProductOfSeq(getValAt(k), ras.ToDict()[k])))
 }
 
-// Helper accessors returning a single seq for a given key (force single-typed lookup).
+// Returns the sequence of active elements for a given reference.
 ghost
 requires acc(&inUseIdx)
 decreases

--- a/resalgebraNoAxioms/loc.gobra
+++ b/resalgebraNoAxioms/loc.gobra
@@ -164,7 +164,7 @@ pred GlobalMem() {
 					ras.ToDict()[k].IsElem(ras.ToDict()[k].Compose(i.val, i2.val)) &&
 					ras.ToDict()[k].IsValid(ras.ToDict()[k].Compose(i.val, i2.val))))) &&
 	// In-use value tracking: per-location seqs of currently-in-use idx pointers and their
-	// values. Foundation for the product-of-in-use-values invariant.
+	// values.
 	domain(toDict(model)) subset domain(inUseIdx) &&
 	domain(toDict(model)) subset domain(inUseVal) &&
 	(forall k LocName :: k elem domain(toDict(model)) ==>

--- a/resalgebraNoAxioms/loc.gobra
+++ b/resalgebraNoAxioms/loc.gobra
@@ -195,14 +195,14 @@ pred GlobalMem() {
 
 // Helper accessors returning a single seq for a given key (force single-typed lookup).
 ghost
-requires acc(&inUseIdx, _)
+requires acc(&inUseIdx)
 decreases
 pure func getIdxAt(k LocName) seq[idx] {
 	return idxSeqLookup(inUseIdx, k)
 }
 
 ghost
-requires acc(&inUseVal, _)
+requires acc(&inUseVal)
 decreases
 pure func getValAt(k LocName) seq[Elem] {
 	return valSeqLookup(inUseVal, k)
@@ -222,7 +222,6 @@ pure func valSeqLookup(d dict[LocName](seq[Elem]), k LocName) seq[Elem] {
 
 // Find the (first) position of x in s. Requires x to be present in s.
 ghost
-requires len(s) >= 1
 requires x elem s
 ensures  0 <= res && res < len(s)
 ensures  s[res] === x

--- a/resalgebraNoAxioms/product.gobra
+++ b/resalgebraNoAxioms/product.gobra
@@ -207,8 +207,7 @@ func ExtractOneValid(s seq[Elem], ra RA, p int) {
 	}
 }
 
-// Split lemma (inductive on `pre`):
-//   ProductOfSeq(pre ++ [a] ++ post ++ [b]) === ProductOfSeq(pre ++ [Compose(a,b)] ++ post)
+// ProductOfSeq(pre ++ [a] ++ post ++ [b]) === ProductOfSeq(pre ++ [Compose(a,b)] ++ post)
 ghost
 requires ra != nil
 requires ra.IsElem(a) && ra.IsElem(b)
@@ -314,7 +313,6 @@ func ProductMergeAt(s seq[Elem], p1 int, p2 int, ra RA) {
 // preserves product validity.
 ghost
 requires ra != nil
-requires 0 < len(s)
 requires 0 <= posI && posI < len(s)
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 requires ra.IsElem(e1) && ra.IsElem(e2)

--- a/resalgebraNoAxioms/product.gobra
+++ b/resalgebraNoAxioms/product.gobra
@@ -36,7 +36,6 @@ requires ra != nil
 requires 0 < len(s1) && 0 < len(s2)
 requires forall j int :: { s1[j] } 0 <= j && j < len(s1) ==> ra.IsElem(s1[j])
 requires forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])
-ensures  forall j int :: { (s1 ++ s2)[j] } 0 <= j && j < len(s1 ++ s2) ==> ra.IsElem((s1 ++ s2)[j])
 ensures  ProductOfSeq(s1 ++ s2, ra) === ra.Compose(ProductOfSeq(s1, ra), ProductOfSeq(s2, ra))
 decreases len(s1)
 pure func ProductOfSeqConcat(s1 seq[Elem], s2 seq[Elem], ra RA) Unit {
@@ -129,13 +128,12 @@ pure func ProductOfSeqMoveFront(s seq[Elem], ra RA, k int) Unit {
 ghost
 opaque
 requires ra != nil
-requires len(s) >= 3
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
-requires ra.IsValid(ProductOfSeq(s, ra))
 requires 0 <= p1 && p1 < len(s)
 requires 0 <= p2 && p2 < len(s)
 requires 0 <= p3 && p3 < len(s)
 requires p1 != p2 && p1 != p3 && p2 != p3
+requires ra.IsValid(ProductOfSeq(s, ra))
 ensures  ra.IsElem(ra.Compose(ra.Compose(s[p1], s[p2]), s[p3]))
 ensures  ra.IsValid(ra.Compose(ra.Compose(s[p1], s[p2]), s[p3]))
 decreases
@@ -182,10 +180,9 @@ pure func ExtractThreeValid(s seq[Elem], ra RA, p1 int, p2 int, p3 int) Unit {
 // (Non-pure variant retained for the lemma chain in maintenance proofs.)
 ghost
 requires ra != nil
-requires 0 < len(s)
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
-requires ra.IsValid(ProductOfSeq(s, ra))
 requires 0 <= p && p < len(s)
+requires ra.IsValid(ProductOfSeq(s, ra))
 ensures  len(s) == 1 ==> ra.IsValid(s[p])
 ensures  len(s) >= 2 ==>
 	let rest := s[:p] ++ s[p+1:] in
@@ -262,7 +259,6 @@ func ProductSplitEq(pre seq[Elem], post seq[Elem], a Elem, b Elem, ra RA) {
 // The merged value lives at min(p1, p2); max(p1, p2) is removed.
 ghost
 requires ra != nil
-requires len(s) >= 2
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 requires 0 <= p1 && p1 < len(s)
 requires 0 <= p2 && p2 < len(s)
@@ -272,7 +268,6 @@ ensures  let pmin := p1 < p2 ? p1 : p2 in
 	let pmax := p1 < p2 ? p2 : p1 in
 	let merged := ra.Compose(s[p1], s[p2]) in
 	let s2 := s[:pmin] ++ seq[Elem]{merged} ++ s[pmin+1:pmax] ++ s[pmax+1:] in
-	len(s2) == len(s) - 1 &&
 	ra.IsValid(ProductOfSeq(s2, ra))
 decreases
 func ProductMergeAt(s seq[Elem], p1 int, p2 int, ra RA) {
@@ -320,7 +315,6 @@ requires s[posI] === e1
 requires IsFramePreservingUpdate(ra, e1, e2)
 requires ra.IsValid(ProductOfSeq(s, ra))
 ensures  let s2 := s[:posI] ++ seq[Elem]{e2} ++ s[posI+1:] in
-	len(s2) == len(s) &&
 	ra.IsValid(ProductOfSeq(s2, ra))
 decreases
 func ProductFPUEq(s seq[Elem], posI int, e1 Elem, e2 Elem, ra RA) {

--- a/resalgebraNoAxioms/product.gobra
+++ b/resalgebraNoAxioms/product.gobra
@@ -190,8 +190,6 @@ ensures  len(s) == 1 ==> ra.IsValid(s[p])
 ensures  len(s) >= 2 ==>
 	let rest := s[:p] ++ s[p+1:] in
 	len(rest) == len(s) - 1 &&
-	(forall j int :: 0 <= j && j < len(rest) ==> ra.IsElem(rest[j])) &&
-	ra.IsElem(ra.Compose(s[p], ProductOfSeq(rest, ra))) &&
 	ra.IsValid(ra.Compose(s[p], ProductOfSeq(rest, ra)))
 decreases
 func ExtractOneValid(s seq[Elem], ra RA, p int) {
@@ -216,10 +214,6 @@ requires ra != nil
 requires ra.IsElem(a) && ra.IsElem(b)
 requires forall j int :: { pre[j] } 0 <= j && j < len(pre) ==> ra.IsElem(pre[j])
 requires forall j int :: { post[j] } 0 <= j && j < len(post) ==> ra.IsElem(post[j])
-ensures  let lhs := pre ++ seq[Elem]{a} ++ post ++ seq[Elem]{b} in
-	(forall j int :: { lhs[j] } 0 <= j && j < len(lhs) ==> ra.IsElem(lhs[j]))
-ensures  let rhs := pre ++ seq[Elem]{ra.Compose(a, b)} ++ post in
-	(forall j int :: { rhs[j] } 0 <= j && j < len(rhs) ==> ra.IsElem(rhs[j]))
 ensures  ProductOfSeq(pre ++ seq[Elem]{a} ++ post ++ seq[Elem]{b}, ra) ===
 	ProductOfSeq(pre ++ seq[Elem]{ra.Compose(a, b)} ++ post, ra)
 decreases len(pre)
@@ -275,13 +269,11 @@ requires 0 <= p1 && p1 < len(s)
 requires 0 <= p2 && p2 < len(s)
 requires p1 != p2
 requires ra.IsValid(ProductOfSeq(s, ra))
-ensures  ra.IsElem(ra.Compose(s[p1], s[p2]))
 ensures  let pmin := p1 < p2 ? p1 : p2 in
 	let pmax := p1 < p2 ? p2 : p1 in
 	let merged := ra.Compose(s[p1], s[p2]) in
 	let s2 := s[:pmin] ++ seq[Elem]{merged} ++ s[pmin+1:pmax] ++ s[pmax+1:] in
 	len(s2) == len(s) - 1 &&
-	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
 	ra.IsValid(ProductOfSeq(s2, ra))
 decreases
 func ProductMergeAt(s seq[Elem], p1 int, p2 int, ra RA) {
@@ -331,7 +323,6 @@ requires IsFramePreservingUpdate(ra, e1, e2)
 requires ra.IsValid(ProductOfSeq(s, ra))
 ensures  let s2 := s[:posI] ++ seq[Elem]{e2} ++ s[posI+1:] in
 	len(s2) == len(s) &&
-	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
 	ra.IsValid(ProductOfSeq(s2, ra))
 decreases
 func ProductFPUEq(s seq[Elem], posI int, e1 Elem, e2 Elem, ra RA) {

--- a/resalgebraNoAxioms/product.gobra
+++ b/resalgebraNoAxioms/product.gobra
@@ -1,0 +1,398 @@
+// Copyright 2025 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +gobra
+
+package resalgebraNoAxioms
+
+// ProductOfSeq composes all elements of `s` under `ra`. The sequence must be
+// non-empty. Used by GlobalMem() to state the invariant that the composition
+// of all in-use values at a location is valid.
+
+ghost
+requires ra != nil
+requires len(s) >= 1
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+ensures  ra.IsElem(res)
+decreases len(s)
+pure func ProductOfSeq(s seq[Elem], ra RA) (res Elem) {
+	return len(s) == 1 ?
+		s[0] :
+		ra.Compose(s[0], ProductOfSeq(s[1:], ra))
+}
+
+// Concatenation: ProductOfSeq(s1 ++ s2) === Compose(ProductOfSeq(s1), ProductOfSeq(s2)).
+//
+// `pure` so it can be used inside `let _ := ...` chains in forall bodies.
+
+ghost
+requires ra != nil
+requires len(s1) >= 1 && len(s2) >= 1
+requires forall j int :: { s1[j] } 0 <= j && j < len(s1) ==> ra.IsElem(s1[j])
+requires forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])
+ensures  forall j int :: { (s1 ++ s2)[j] } 0 <= j && j < len(s1 ++ s2) ==> ra.IsElem((s1 ++ s2)[j])
+ensures  ProductOfSeq(s1 ++ s2, ra) === ra.Compose(ProductOfSeq(s1, ra), ProductOfSeq(s2, ra))
+decreases len(s1)
+pure func ProductOfSeqConcat(s1 seq[Elem], s2 seq[Elem], ra RA) Unit {
+	return len(s1) == 1 ?
+		(let _ := asserting((s1 ++ s2)[1:] === s2) in
+		 let _ := asserting(ProductOfSeq(s1, ra) === s1[0]) in
+		 Unit{}) :
+		(let _ := ProductOfSeqConcat(s1[1:], s2, ra) in
+		 let _ := asserting((s1 ++ s2)[1:] === s1[1:] ++ s2) in
+		 let _ := ra.ComposeAssoc(s1[0], ProductOfSeq(s1[1:], ra), ProductOfSeq(s2, ra)) in
+		 let _ := asserting(ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra))) in
+		 Unit{})
+}
+
+// Swap positions k and k+1: ProductOfSeq(s) === ProductOfSeq(swap(s, k)).
+// Pure recursion on k.
+
+ghost
+requires ra != nil
+requires len(s) >= 2
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+requires 0 <= k && k + 1 < len(s)
+ensures  let s2 := s[:k] ++ seq[Elem]{s[k+1], s[k]} ++ s[k+2:] in
+	len(s2) == len(s) &&
+	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
+	ProductOfSeq(s, ra) === ProductOfSeq(s2, ra)
+decreases k
+pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
+	return k == 0 ?
+		(let a := s[0] in
+		 let b := s[1] in
+		 let rest := s[2:] in
+		 let s2 := s[:0] ++ seq[Elem]{s[1], s[0]} ++ s[2:] in
+		 len(rest) == 0 ?
+			(let _ := asserting(s === seq[Elem]{a, b}) in
+			 let _ := asserting(s[1:] === seq[Elem]{b}) in
+			 let _ := asserting(ProductOfSeq(s[1:], ra) === b) in
+			 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(a, b)) in
+			 let _ := asserting(s2 === seq[Elem]{b, a}) in
+			 let _ := asserting(s2[1:] === seq[Elem]{a}) in
+			 let _ := asserting(ProductOfSeq(s2[1:], ra) === a) in
+			 let _ := asserting(ProductOfSeq(s2, ra) === ra.Compose(b, a)) in
+			 let _ := ra.ComposeComm(a, b) in
+			 Unit{}) :
+			(let _ := asserting(s === seq[Elem]{a, b} ++ rest) in
+			 let _ := asserting(s[1:] === seq[Elem]{b} ++ rest) in
+			 let _ := asserting((s[1:])[0] === b) in
+			 let _ := asserting((s[1:])[1:] === rest) in
+			 let _ := asserting(ProductOfSeq(s[1:], ra) === ra.Compose(b, ProductOfSeq(rest, ra))) in
+			 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(a, ra.Compose(b, ProductOfSeq(rest, ra)))) in
+			 let _ := asserting(s2 === seq[Elem]{b, a} ++ rest) in
+			 let _ := asserting(s2[1:] === seq[Elem]{a} ++ rest) in
+			 let _ := asserting((s2[1:])[0] === a) in
+			 let _ := asserting((s2[1:])[1:] === rest) in
+			 let _ := asserting(ProductOfSeq(s2[1:], ra) === ra.Compose(a, ProductOfSeq(rest, ra))) in
+			 let _ := asserting(ProductOfSeq(s2, ra) === ra.Compose(b, ra.Compose(a, ProductOfSeq(rest, ra)))) in
+			 let _ := ra.ComposeAssoc(a, b, ProductOfSeq(rest, ra)) in
+			 let _ := ra.ComposeAssoc(b, a, ProductOfSeq(rest, ra)) in
+			 let _ := ra.ComposeComm(a, b) in
+			 Unit{})) :
+		(let _ := AdjacentSwapProduct(s[1:], ra, k - 1) in
+		 let tail := s[1:] in
+		 let tailSwapped := tail[:k-1] ++ seq[Elem]{tail[k], tail[k-1]} ++ tail[k+1:] in
+		 let sSwapped := s[:k] ++ seq[Elem]{s[k+1], s[k]} ++ s[k+2:] in
+		 let _ := asserting(sSwapped[0] === s[0]) in
+		 let _ := asserting(sSwapped[1:] === tailSwapped) in
+		 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(s[0], ProductOfSeq(tail, ra))) in
+		 let _ := asserting(ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra))) in
+		 Unit{})
+}
+
+// Move position k to the front: ProductOfSeq(s) === ProductOfSeq([s[k]] ++ s[:k] ++ s[k+1:]).
+
+ghost
+requires ra != nil
+requires len(s) >= 1
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+requires 0 <= k && k < len(s)
+ensures  let s2 := seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] in
+	len(s2) == len(s) &&
+	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
+	ProductOfSeq(s, ra) === ProductOfSeq(s2, ra)
+decreases k
+pure func ProductOfSeqMoveFront(s seq[Elem], ra RA, k int) Unit {
+	return k == 0 ?
+		(let _ := asserting(s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:]) in
+		 Unit{}) :
+		(let _ := AdjacentSwapProduct(s, ra, k - 1) in
+		 let sSwapped := s[:k-1] ++ seq[Elem]{s[k], s[k-1]} ++ s[k+1:] in
+		 let _ := ProductOfSeqMoveFront(sSwapped, ra, k - 1) in
+		 let _ := asserting(sSwapped[k-1] === s[k]) in
+		 let _ := asserting(sSwapped[:k-1] === s[:k-1]) in
+		 let _ := asserting(sSwapped[k:] === seq[Elem]{s[k-1]} ++ s[k+1:]) in
+		 let _ := asserting(s[:k] === s[:k-1] ++ seq[Elem]{s[k-1]}) in
+		 let _ := asserting(seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
+			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:]) in
+		 Unit{})
+}
+
+// Given ProductOfSeq(s) is valid, and three distinct positions p1, p2, p3,
+// derive that Compose(Compose(s[p1], s[p2]), s[p3]) is valid.
+// `pure` so it is callable from forall bodies via `let _ := ...`.
+
+ghost
+requires ra != nil
+requires len(s) >= 3
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+requires ra.IsValid(ProductOfSeq(s, ra))
+requires 0 <= p1 && p1 < len(s)
+requires 0 <= p2 && p2 < len(s)
+requires 0 <= p3 && p3 < len(s)
+requires p1 != p2 && p1 != p3 && p2 != p3
+ensures  ra.IsElem(ra.Compose(ra.Compose(s[p1], s[p2]), s[p3]))
+ensures  ra.IsValid(ra.Compose(ra.Compose(s[p1], s[p2]), s[p3]))
+decreases
+pure func ExtractThreeValid(s seq[Elem], ra RA, p1 int, p2 int, p3 int) Unit {
+	return let _ := ProductOfSeqMoveFront(s, ra, p3) in
+		let sA := seq[Elem]{s[p3]} ++ s[:p3] ++ s[p3+1:] in
+		let qA1 := p1 < p3 ? p1 + 1 : p1 in
+		let qA2 := p2 < p3 ? p2 + 1 : p2 in
+		let _ := asserting(sA[qA1] === s[p1]) in
+		let _ := asserting(sA[qA2] === s[p2]) in
+		let _ := asserting(qA1 != qA2) in
+		let _ := ProductOfSeqMoveFront(sA, ra, qA2) in
+		let sB := seq[Elem]{sA[qA2]} ++ sA[:qA2] ++ sA[qA2+1:] in
+		let _ := asserting(sB[0] === s[p2]) in
+		let _ := asserting(sB[1] === s[p3]) in
+		let qB1 := qA1 < qA2 ? qA1 + 1 : qA1 in
+		let _ := asserting(sB[qB1] === s[p1]) in
+		let _ := asserting(qB1 >= 2) in
+		let _ := ProductOfSeqMoveFront(sB, ra, qB1) in
+		let sC := seq[Elem]{sB[qB1]} ++ sB[:qB1] ++ sB[qB1+1:] in
+		let _ := asserting(sC[0] === s[p1]) in
+		let _ := asserting(sC[1] === s[p2]) in
+		let _ := asserting(sC[2] === s[p3]) in
+		let sHead := seq[Elem]{s[p1], s[p2], s[p3]} in
+		let _ := asserting(sHead[1:] === seq[Elem]{s[p2], s[p3]}) in
+		let _ := asserting((sHead[1:])[0] === s[p2]) in
+		let _ := asserting((sHead[1:])[1:] === seq[Elem]{s[p3]}) in
+		let _ := asserting(ProductOfSeq(seq[Elem]{s[p3]}, ra) === s[p3]) in
+		let _ := asserting(ProductOfSeq(sHead[1:], ra) === ra.Compose(s[p2], s[p3])) in
+		let _ := asserting(ProductOfSeq(sHead, ra) === ra.Compose(s[p1], ra.Compose(s[p2], s[p3]))) in
+		let _ := ra.ComposeAssoc(s[p1], s[p2], s[p3]) in
+		let _ := asserting(ProductOfSeq(sHead, ra) === ra.Compose(ra.Compose(s[p1], s[p2]), s[p3])) in
+		(len(s) == 3 ?
+			(let _ := asserting(sC === sHead) in Unit{}) :
+			(let sTail := sC[3:] in
+			 let _ := asserting(sC === sHead ++ sTail) in
+			 let _ := ProductOfSeqConcat(sHead, sTail, ra) in
+			 let _ := asserting(ProductOfSeq(sC, ra) ===
+				ra.Compose(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))) in
+			 let _ := ra.ValidOp(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra)) in
+			 Unit{}))
+}
+
+// Given ProductOfSeq(s) is valid, split out the value at position p.
+// (Non-pure variant retained for the lemma chain in maintenance proofs.)
+
+ghost
+requires ra != nil
+requires len(s) >= 1
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+requires ra.IsValid(ProductOfSeq(s, ra))
+requires 0 <= p && p < len(s)
+ensures  len(s) == 1 ==> ra.IsValid(s[p])
+ensures  len(s) >= 2 ==>
+	let rest := s[:p] ++ s[p+1:] in
+	len(rest) == len(s) - 1 &&
+	(forall j int :: 0 <= j && j < len(rest) ==> ra.IsElem(rest[j])) &&
+	ra.IsElem(ra.Compose(s[p], ProductOfSeq(rest, ra))) &&
+	ra.IsValid(ra.Compose(s[p], ProductOfSeq(rest, ra)))
+decreases
+func ExtractOneValid(s seq[Elem], ra RA, p int) {
+	ProductOfSeqMoveFront(s, ra, p)
+	sA := seq[Elem]{s[p]} ++ s[:p] ++ s[p+1:]
+	if len(s) == 1 {
+		assert sA === seq[Elem]{s[p]}
+		assert ProductOfSeq(sA, ra) === s[p]
+	} else {
+		rest := s[:p] ++ s[p+1:]
+		assert sA === seq[Elem]{s[p]} ++ rest
+		ProductOfSeqConcat(seq[Elem]{s[p]}, rest, ra)
+		assert ProductOfSeq(seq[Elem]{s[p]}, ra) === s[p]
+		assert ProductOfSeq(sA, ra) === ra.Compose(s[p], ProductOfSeq(rest, ra))
+	}
+}
+
+// Split lemma (inductive on `pre`):
+//   ProductOfSeq(pre ++ [a] ++ post ++ [b]) === ProductOfSeq(pre ++ [Compose(a,b)] ++ post)
+ghost
+requires ra != nil
+requires ra.IsElem(a) && ra.IsElem(b)
+requires forall j int :: { pre[j] } 0 <= j && j < len(pre) ==> ra.IsElem(pre[j])
+requires forall j int :: { post[j] } 0 <= j && j < len(post) ==> ra.IsElem(post[j])
+ensures  let lhs := pre ++ seq[Elem]{a} ++ post ++ seq[Elem]{b} in
+	(forall j int :: { lhs[j] } 0 <= j && j < len(lhs) ==> ra.IsElem(lhs[j]))
+ensures  let rhs := pre ++ seq[Elem]{ra.Compose(a, b)} ++ post in
+	(forall j int :: { rhs[j] } 0 <= j && j < len(rhs) ==> ra.IsElem(rhs[j]))
+ensures  ProductOfSeq(pre ++ seq[Elem]{a} ++ post ++ seq[Elem]{b}, ra) ===
+	ProductOfSeq(pre ++ seq[Elem]{ra.Compose(a, b)} ++ post, ra)
+decreases len(pre)
+func ProductSplitEq(pre seq[Elem], post seq[Elem], a Elem, b Elem, ra RA) {
+	lhs := pre ++ seq[Elem]{a} ++ post ++ seq[Elem]{b}
+	rhs := pre ++ seq[Elem]{ra.Compose(a, b)} ++ post
+
+	if len(pre) == 0 {
+		assert pre === seq[Elem]{}
+		assert lhs === seq[Elem]{a} ++ post ++ seq[Elem]{b}
+		assert rhs === seq[Elem]{ra.Compose(a, b)} ++ post
+		if len(post) == 0 {
+			assert lhs === seq[Elem]{a, b}
+			assert rhs === seq[Elem]{ra.Compose(a, b)}
+			assert lhs[1:] === seq[Elem]{b}
+			assert ProductOfSeq(lhs[1:], ra) === b
+			assert ProductOfSeq(lhs, ra) === ra.Compose(a, b)
+			assert ProductOfSeq(rhs, ra) === ra.Compose(a, b)
+		} else {
+			P := ProductOfSeq(post, ra)
+			ProductOfSeqConcat(post, seq[Elem]{b}, ra)
+			assert ProductOfSeq(post ++ seq[Elem]{b}, ra) === ra.Compose(P, b)
+			assert lhs[0] === a
+			assert lhs[1:] === post ++ seq[Elem]{b}
+			assert ProductOfSeq(lhs, ra) === ra.Compose(a, ra.Compose(P, b))
+			assert rhs[0] === ra.Compose(a, b)
+			assert rhs[1:] === post
+			assert ProductOfSeq(rhs, ra) === ra.Compose(ra.Compose(a, b), P)
+			ra.ComposeComm(P, b)
+			ra.ComposeAssoc(a, b, P)
+		}
+	} else {
+		ProductSplitEq(pre[1:], post, a, b, ra)
+		lhsTail := pre[1:] ++ seq[Elem]{a} ++ post ++ seq[Elem]{b}
+		rhsTail := pre[1:] ++ seq[Elem]{ra.Compose(a, b)} ++ post
+		assert lhs[0] === pre[0]
+		assert lhs[1:] === lhsTail
+		assert rhs[0] === pre[0]
+		assert rhs[1:] === rhsTail
+		assert ProductOfSeq(lhs, ra) === ra.Compose(pre[0], ProductOfSeq(lhsTail, ra))
+		assert ProductOfSeq(rhs, ra) === ra.Compose(pre[0], ProductOfSeq(rhsTail, ra))
+	}
+}
+
+// Merge lemma: merging two distinct positions p1 (with value e1) and p2 (with value e2)
+// of a valid product seq into a single position holding Compose(e1, e2) preserves validity.
+// The merged value lives at min(p1, p2); max(p1, p2) is removed.
+ghost
+requires ra != nil
+requires len(s) >= 2
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+requires 0 <= p1 && p1 < len(s)
+requires 0 <= p2 && p2 < len(s)
+requires p1 != p2
+requires ra.IsValid(ProductOfSeq(s, ra))
+ensures  ra.IsElem(ra.Compose(s[p1], s[p2]))
+ensures  let pmin := p1 < p2 ? p1 : p2 in
+	let pmax := p1 < p2 ? p2 : p1 in
+	let merged := ra.Compose(s[p1], s[p2]) in
+	let s2 := s[:pmin] ++ seq[Elem]{merged} ++ s[pmin+1:pmax] ++ s[pmax+1:] in
+	len(s2) == len(s) - 1 &&
+	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
+	ra.IsValid(ProductOfSeq(s2, ra))
+decreases
+func ProductMergeAt(s seq[Elem], p1 int, p2 int, ra RA) {
+	pmin := p1 < p2 ? p1 : p2
+	pmax := p1 < p2 ? p2 : p1
+	pre := s[:pmin]
+	mid := s[pmin+1:pmax]
+	tail := s[pmax+1:]
+	a := s[pmin]
+	b := s[pmax]
+	merged := ra.Compose(s[p1], s[p2])
+
+	if p1 < p2 {
+		ProductSplitEq(pre, mid, a, b, ra)
+	} else {
+		ProductSplitEq(pre, mid, a, b, ra)
+		ra.ComposeComm(s[p1], s[p2])
+		ra.ComposeComm(a, b)
+	}
+	splitLeft := pre ++ seq[Elem]{a} ++ mid ++ seq[Elem]{b}
+	splitRight := pre ++ seq[Elem]{merged} ++ mid
+	assert ProductOfSeq(splitLeft, ra) === ProductOfSeq(splitRight, ra)
+
+	assert s === splitLeft ++ tail
+	s2 := splitRight ++ tail
+
+	if len(tail) == 0 {
+		assert s === splitLeft
+		assert s2 === splitRight
+	} else {
+		ProductOfSeqConcat(splitLeft, tail, ra)
+		ProductOfSeqConcat(splitRight, tail, ra)
+	}
+	assert ProductOfSeq(s, ra) === ProductOfSeq(s2, ra)
+}
+
+// Frame-preserving update lemma: replacing s[posI] = e1 with e2 (under IsFramePreservingUpdate)
+// preserves product validity.
+ghost
+requires ra != nil
+requires len(s) >= 1
+requires 0 <= posI && posI < len(s)
+requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
+requires ra.IsElem(e1) && ra.IsElem(e2)
+requires s[posI] === e1
+requires IsFramePreservingUpdate(ra, e1, e2)
+requires ra.IsValid(ProductOfSeq(s, ra))
+ensures  let s2 := s[:posI] ++ seq[Elem]{e2} ++ s[posI+1:] in
+	len(s2) == len(s) &&
+	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
+	ra.IsValid(ProductOfSeq(s2, ra))
+decreases
+func ProductFPUEq(s seq[Elem], posI int, e1 Elem, e2 Elem, ra RA) {
+	s2 := s[:posI] ++ seq[Elem]{e2} ++ s[posI+1:]
+	assert len(s2) == len(s)
+	assert forall j int :: 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])
+
+	if len(s) == 1 {
+		assert s === seq[Elem]{e1}
+		assert s2 === seq[Elem]{e2}
+		assert ProductOfSeq(s, ra) === e1
+		assert ProductOfSeq(s2, ra) === e2
+		assert LiftedCompose(ra, some(e1), none[Elem]) === some(e1)
+		assert LiftedCompose(ra, some(e2), none[Elem]) === some(e2)
+		assert LiftedIsValid(ra, some(e1)) === ra.IsValid(e1)
+		assert LiftedIsValid(ra, some(e2)) === ra.IsValid(e2)
+		assert ra.IsValid(e1)
+	} else {
+		ProductOfSeqMoveFront(s, ra, posI)
+		sFront := seq[Elem]{s[posI]} ++ s[:posI] ++ s[posI+1:]
+		assert sFront === seq[Elem]{e1} ++ s[:posI] ++ s[posI+1:]
+		ProductOfSeqMoveFront(s2, ra, posI)
+		s2Front := seq[Elem]{s2[posI]} ++ s2[:posI] ++ s2[posI+1:]
+		assert s2[posI] === e2
+		assert s2[:posI] === s[:posI]
+		assert s2[posI+1:] === s[posI+1:]
+		assert s2Front === seq[Elem]{e2} ++ s[:posI] ++ s[posI+1:]
+		rest := s[:posI] ++ s[posI+1:]
+		assert len(rest) == len(s) - 1
+		assert len(rest) >= 1
+		assert sFront === seq[Elem]{e1} ++ rest
+		assert s2Front === seq[Elem]{e2} ++ rest
+		assert sFront[0] === e1 && sFront[1:] === rest
+		assert s2Front[0] === e2 && s2Front[1:] === rest
+		assert ProductOfSeq(sFront, ra) === ra.Compose(e1, ProductOfSeq(rest, ra))
+		assert ProductOfSeq(s2Front, ra) === ra.Compose(e2, ProductOfSeq(rest, ra))
+		c := ProductOfSeq(rest, ra)
+		assert ra.IsElem(c)
+		assert LiftedCompose(ra, some(e1), some(c)) === some(ra.Compose(e1, c))
+		assert LiftedCompose(ra, some(e2), some(c)) === some(ra.Compose(e2, c))
+		assert LiftedIsValid(ra, some(ra.Compose(e1, c))) === ra.IsValid(ra.Compose(e1, c))
+		assert LiftedIsValid(ra, some(ra.Compose(e2, c))) === ra.IsValid(ra.Compose(e2, c))
+	}
+}

--- a/resalgebraNoAxioms/product.gobra
+++ b/resalgebraNoAxioms/product.gobra
@@ -16,13 +16,10 @@
 
 package resalgebraNoAxioms
 
-// ProductOfSeq composes all elements of `s` under `ra`. The sequence must be
-// non-empty. Used by GlobalMem() to state the invariant that the composition
-// of all in-use values at a location is valid.
-
+// ProductOfSeq composes all elements of `s` under `ra`.
 ghost
 requires ra != nil
-requires len(s) >= 1
+requires 0 < len(s)
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 ensures  ra.IsElem(res)
 decreases len(s)
@@ -33,12 +30,10 @@ pure func ProductOfSeq(s seq[Elem], ra RA) (res Elem) {
 }
 
 // Concatenation: ProductOfSeq(s1 ++ s2) === Compose(ProductOfSeq(s1), ProductOfSeq(s2)).
-//
-// `pure` so it can be used inside `let _ := ...` chains in forall bodies.
-
 ghost
+opaque
 requires ra != nil
-requires len(s1) >= 1 && len(s2) >= 1
+requires 0 < len(s1) && 0 < len(s2)
 requires forall j int :: { s1[j] } 0 <= j && j < len(s1) ==> ra.IsElem(s1[j])
 requires forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])
 ensures  forall j int :: { (s1 ++ s2)[j] } 0 <= j && j < len(s1 ++ s2) ==> ra.IsElem((s1 ++ s2)[j])
@@ -47,26 +42,21 @@ decreases len(s1)
 pure func ProductOfSeqConcat(s1 seq[Elem], s2 seq[Elem], ra RA) Unit {
 	return len(s1) == 1 ?
 		(let _ := asserting((s1 ++ s2)[1:] === s2) in
-		 let _ := asserting(ProductOfSeq(s1, ra) === s1[0]) in
-		 Unit{}) :
+		 asserting(ProductOfSeq(s1, ra) === s1[0])) :
 		(let _ := ProductOfSeqConcat(s1[1:], s2, ra) in
 		 let _ := asserting((s1 ++ s2)[1:] === s1[1:] ++ s2) in
 		 let _ := ra.ComposeAssoc(s1[0], ProductOfSeq(s1[1:], ra), ProductOfSeq(s2, ra)) in
-		 let _ := asserting(ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra))) in
-		 Unit{})
+		 asserting(ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra))))
 }
 
 // Swap positions k and k+1: ProductOfSeq(s) === ProductOfSeq(swap(s, k)).
-// Pure recursion on k.
-
 ghost
+opaque
 requires ra != nil
-requires len(s) >= 2
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 requires 0 <= k && k + 1 < len(s)
 ensures  let s2 := s[:k] ++ seq[Elem]{s[k+1], s[k]} ++ s[k+2:] in
 	len(s2) == len(s) &&
-	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
 	ProductOfSeq(s, ra) === ProductOfSeq(s2, ra)
 decreases k
 pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
@@ -84,8 +74,7 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 			 let _ := asserting(s2[1:] === seq[Elem]{a}) in
 			 let _ := asserting(ProductOfSeq(s2[1:], ra) === a) in
 			 let _ := asserting(ProductOfSeq(s2, ra) === ra.Compose(b, a)) in
-			 let _ := ra.ComposeComm(a, b) in
-			 Unit{}) :
+			 ra.ComposeComm(a, b)) :
 			(let _ := asserting(s === seq[Elem]{a, b} ++ rest) in
 			 let _ := asserting(s[1:] === seq[Elem]{b} ++ rest) in
 			 let _ := asserting((s[1:])[0] === b) in
@@ -100,8 +89,7 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 			 let _ := asserting(ProductOfSeq(s2, ra) === ra.Compose(b, ra.Compose(a, ProductOfSeq(rest, ra)))) in
 			 let _ := ra.ComposeAssoc(a, b, ProductOfSeq(rest, ra)) in
 			 let _ := ra.ComposeAssoc(b, a, ProductOfSeq(rest, ra)) in
-			 let _ := ra.ComposeComm(a, b) in
-			 Unit{})) :
+			 ra.ComposeComm(a, b))) :
 		(let _ := AdjacentSwapProduct(s[1:], ra, k - 1) in
 		 let tail := s[1:] in
 		 let tailSwapped := tail[:k-1] ++ seq[Elem]{tail[k], tail[k-1]} ++ tail[k+1:] in
@@ -109,26 +97,22 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 		 let _ := asserting(sSwapped[0] === s[0]) in
 		 let _ := asserting(sSwapped[1:] === tailSwapped) in
 		 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(s[0], ProductOfSeq(tail, ra))) in
-		 let _ := asserting(ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra))) in
-		 Unit{})
+		 asserting(ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra))))
 }
 
 // Move position k to the front: ProductOfSeq(s) === ProductOfSeq([s[k]] ++ s[:k] ++ s[k+1:]).
-
 ghost
+opaque
 requires ra != nil
-requires len(s) >= 1
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 requires 0 <= k && k < len(s)
 ensures  let s2 := seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] in
 	len(s2) == len(s) &&
-	(forall j int :: { s2[j] } 0 <= j && j < len(s2) ==> ra.IsElem(s2[j])) &&
 	ProductOfSeq(s, ra) === ProductOfSeq(s2, ra)
 decreases k
 pure func ProductOfSeqMoveFront(s seq[Elem], ra RA, k int) Unit {
 	return k == 0 ?
-		(let _ := asserting(s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:]) in
-		 Unit{}) :
+		asserting(s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:]) :
 		(let _ := AdjacentSwapProduct(s, ra, k - 1) in
 		 let sSwapped := s[:k-1] ++ seq[Elem]{s[k], s[k-1]} ++ s[k+1:] in
 		 let _ := ProductOfSeqMoveFront(sSwapped, ra, k - 1) in
@@ -136,16 +120,14 @@ pure func ProductOfSeqMoveFront(s seq[Elem], ra RA, k int) Unit {
 		 let _ := asserting(sSwapped[:k-1] === s[:k-1]) in
 		 let _ := asserting(sSwapped[k:] === seq[Elem]{s[k-1]} ++ s[k+1:]) in
 		 let _ := asserting(s[:k] === s[:k-1] ++ seq[Elem]{s[k-1]}) in
-		 let _ := asserting(seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
-			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:]) in
-		 Unit{})
+		 asserting(seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
+			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:]))
 }
 
 // Given ProductOfSeq(s) is valid, and three distinct positions p1, p2, p3,
 // derive that Compose(Compose(s[p1], s[p2]), s[p3]) is valid.
-// `pure` so it is callable from forall bodies via `let _ := ...`.
-
 ghost
+opaque
 requires ra != nil
 requires len(s) >= 3
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
@@ -187,22 +169,20 @@ pure func ExtractThreeValid(s seq[Elem], ra RA, p1 int, p2 int, p3 int) Unit {
 		let _ := ra.ComposeAssoc(s[p1], s[p2], s[p3]) in
 		let _ := asserting(ProductOfSeq(sHead, ra) === ra.Compose(ra.Compose(s[p1], s[p2]), s[p3])) in
 		(len(s) == 3 ?
-			(let _ := asserting(sC === sHead) in Unit{}) :
+			asserting(sC === sHead) :
 			(let sTail := sC[3:] in
 			 let _ := asserting(sC === sHead ++ sTail) in
 			 let _ := ProductOfSeqConcat(sHead, sTail, ra) in
 			 let _ := asserting(ProductOfSeq(sC, ra) ===
 				ra.Compose(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))) in
-			 let _ := ra.ValidOp(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra)) in
-			 Unit{}))
+			 ra.ValidOp(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))))
 }
 
 // Given ProductOfSeq(s) is valid, split out the value at position p.
 // (Non-pure variant retained for the lemma chain in maintenance proofs.)
-
 ghost
 requires ra != nil
-requires len(s) >= 1
+requires 0 < len(s)
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 requires ra.IsValid(ProductOfSeq(s, ra))
 requires 0 <= p && p < len(s)
@@ -342,7 +322,7 @@ func ProductMergeAt(s seq[Elem], p1 int, p2 int, ra RA) {
 // preserves product validity.
 ghost
 requires ra != nil
-requires len(s) >= 1
+requires 0 < len(s)
 requires 0 <= posI && posI < len(s)
 requires forall j int :: { s[j] } 0 <= j && j < len(s) ==> ra.IsElem(s[j])
 requires ra.IsElem(e1) && ra.IsElem(e2)


### PR DESCRIPTION
Adds a product-of-in-use-values invariant to GlobalMem() and proves all four ghost operations maintain it. The new `product.gobra` builds up `ProductOfSeq` with the structural lemmas (`Concat`, `AdjacentSwap`, `MoveFront`, `ExtractOne`, `ExtractThree`) and the maintenance lemmas (`ProductSplitEq`, `ProductMergeAt`, `ProductFPUEq`).