### PR TITLE
Refactor asserting/Asserting to use `in` syntax and remove function definitions

### DIFF
--- a/dicts/dicts.gobra
+++ b/dicts/dicts.gobra
@@ -77,7 +77,7 @@ ensures !(k elem domain(d)) ==> len(result) == len(d)
 decreases
 pure func Remove(d dict[int]int, k int) (result dict[int]int) {
 	return let ys := (sets.Remove(domain(d), k)) in
-		asserting (ys intersection domain(d) == ys) in
+		asserting ys intersection domain(d) == ys in
 		RemoveKeys(d, sets.SingletonSet(k))
 }
 
@@ -442,7 +442,8 @@ decreases
 pure func RemoveOccurrences(d dict[int]int, k int) util.Unit {
 	return let ks1 := reveal Keys(d, d[k]) in
 	let ks2 := reveal Keys(Remove(d, k), d[k]) in
-	asserting (ks2 == sets.Remove(ks1, k)) in util.Unit{}
+	asserting ks2 == sets.Remove(ks1, k) in
+	util.Unit{}
 }
 
 // Adding a new key-value pair increases the occurrence of the value by one.
@@ -454,7 +455,8 @@ decreases
 pure func AddOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1 := reveal Keys(d, v) in
 		let ks2 := reveal Keys(d[k = v], v) in
-		asserting (ks2 == sets.Add(ks1, k)) in util.Unit{}
+		asserting ks2 == sets.Add(ks1, k) in
+		util.Unit{}
 }
 
 // Updating a key to a new value results in an additional occurrences for the
@@ -469,10 +471,11 @@ decreases
 pure func UpdateOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1v := reveal Keys(d, v) in
 		let ks2v := reveal Keys(d[k = v], v) in
-		asserting (ks2v == sets.Add(ks1v, k)) in
+		asserting ks2v == sets.Add(ks1v, k) in
 		let ks1dk := reveal Keys(d, d[k]) in
 		let ks2dk := reveal Keys(d[k = v], d[k]) in
-		asserting (ks2dk == sets.Remove(ks1dk, k)) in util.Unit{}
+		asserting ks2dk == sets.Remove(ks1dk, k) in
+		util.Unit{}
 }
 
 // v can occur at most once as a value in injective dictionaries.

--- a/dicts/dicts.gobra
+++ b/dicts/dicts.gobra
@@ -77,7 +77,7 @@ ensures !(k elem domain(d)) ==> len(result) == len(d)
 decreases
 pure func Remove(d dict[int]int, k int) (result dict[int]int) {
 	return let ys := (sets.Remove(domain(d), k)) in
-		let _ := util.Asserting(ys intersection domain(d) == ys) in
+		asserting (ys intersection domain(d) == ys) in
 		RemoveKeys(d, sets.SingletonSet(k))
 }
 
@@ -442,7 +442,7 @@ decreases
 pure func RemoveOccurrences(d dict[int]int, k int) util.Unit {
 	return let ks1 := reveal Keys(d, d[k]) in
 	let ks2 := reveal Keys(Remove(d, k), d[k]) in
-	util.Asserting(ks2 == sets.Remove(ks1, k))
+	asserting (ks2 == sets.Remove(ks1, k)) in util.Unit{}
 }
 
 // Adding a new key-value pair increases the occurrence of the value by one.
@@ -454,7 +454,7 @@ decreases
 pure func AddOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1 := reveal Keys(d, v) in
 		let ks2 := reveal Keys(d[k = v], v) in
-		util.Asserting(ks2 == sets.Add(ks1, k))
+		asserting (ks2 == sets.Add(ks1, k)) in util.Unit{}
 }
 
 // Updating a key to a new value results in an additional occurrences for the
@@ -469,10 +469,10 @@ decreases
 pure func UpdateOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1v := reveal Keys(d, v) in
 		let ks2v := reveal Keys(d[k = v], v) in
-		let _ := util.Asserting(ks2v == sets.Add(ks1v, k)) in
+		asserting (ks2v == sets.Add(ks1v, k)) in
 		let ks1dk := reveal Keys(d, d[k]) in
 		let ks2dk := reveal Keys(d[k = v], d[k]) in
-		util.Asserting(ks2dk == sets.Remove(ks1dk, k))
+		asserting (ks2dk == sets.Remove(ks1dk, k)) in util.Unit{}
 }
 
 // v can occur at most once as a value in injective dictionaries.

--- a/evaluation/experiments/program_proofs_example_10_2/first_half/first_half.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/first_half/first_half.gobra
@@ -17,7 +17,7 @@ pure func (pq PQueue) InsertCorrect(y int) Unit {
 			let min := y < x ? y : x in
 			let max := y < x ? x : y in
 			let newRight := r.Insert(max) in
-			asserting (pqPrime == Node{min, newRight, l}) in
+			asserting pqPrime == Node{min, newRight, l} in
 			asserting (
 				let L := len(l.Elements()) in
 				let R := len(r.Elements()) in

--- a/evaluation/experiments/program_proofs_example_10_2/first_half/first_half.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/first_half/first_half.gobra
@@ -17,8 +17,8 @@ pure func (pq PQueue) InsertCorrect(y int) Unit {
 			let min := y < x ? y : x in
 			let max := y < x ? x : y in
 			let newRight := r.Insert(max) in
-			let _ := asserting(pqPrime == Node{min, newRight, l}) in
-			let _ := asserting(
+			asserting (pqPrime == Node{min, newRight, l}) in
+			asserting (
 				let L := len(l.Elements()) in
 				let R := len(r.Elements()) in
 				L == R || L == R + 1) in
@@ -83,13 +83,6 @@ pure func (pq PQueue) IsBinaryHeap() bool {
 
 
 type Unit struct{}
-
-ghost
-requires b
-decreases
-pure func asserting(b bool) Unit {
-	return Unit{}
-}
 
 ghost type PQueue = BraunTree
 

--- a/evaluation/experiments/program_proofs_example_10_2/full/full.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/full/full.gobra
@@ -17,21 +17,22 @@ pure func (pq PQueue) InsertCorrect(y int) Unit {
 			let min := y < x ? y : x in
 			let max := y < x ? x : y in
 			(let newRight := r.Insert(max) in
-			asserting (pqPrime == Node{min, newRight, l}) in
+			asserting pqPrime == Node{min, newRight, l} in
 			asserting (
 				let L := len(l.Elements()) in
 				let R := len(r.Elements()) in
 				L == R || L == R + 1) in
 			let _ := r.InsertCorrect(max) in
-			asserting (newRight.Valid()) in
-			asserting (newRight.IsBalanced()) in
-			asserting (l.IsBalanced()) in
+			asserting newRight.Valid() in
+			asserting newRight.IsBalanced() in
+			asserting l.IsBalanced() in
 			asserting (
 				let Lprime := len(newRight.Elements()) in
 				let Rprime := len(l.Elements()) in
 				Lprime == Rprime || Lprime == Rprime + 1) in
-			asserting (pqPrime.IsBalanced()) in
-			asserting (pqPrime.IsBinaryHeap()) in Unit{})
+			asserting pqPrime.IsBalanced() in
+			asserting pqPrime.IsBinaryHeap() in
+			Unit{})
 	}
 }
 

--- a/evaluation/experiments/program_proofs_example_10_2/full/full.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/full/full.gobra
@@ -17,21 +17,21 @@ pure func (pq PQueue) InsertCorrect(y int) Unit {
 			let min := y < x ? y : x in
 			let max := y < x ? x : y in
 			(let newRight := r.Insert(max) in
-			let _ := asserting(pqPrime == Node{min, newRight, l}) in
-			let _ := asserting(
+			asserting (pqPrime == Node{min, newRight, l}) in
+			asserting (
 				let L := len(l.Elements()) in
 				let R := len(r.Elements()) in
 				L == R || L == R + 1) in
 			let _ := r.InsertCorrect(max) in
-			let _ := asserting(newRight.Valid()) in
-			let _ := asserting(newRight.IsBalanced()) in
-			let _ := asserting(l.IsBalanced()) in
-			let _ := asserting(
+			asserting (newRight.Valid()) in
+			asserting (newRight.IsBalanced()) in
+			asserting (l.IsBalanced()) in
+			asserting (
 				let Lprime := len(newRight.Elements()) in
 				let Rprime := len(l.Elements()) in
 				Lprime == Rprime || Lprime == Rprime + 1) in
-			let _ := asserting(pqPrime.IsBalanced()) in
-			asserting(pqPrime.IsBinaryHeap()))
+			asserting (pqPrime.IsBalanced()) in
+			asserting (pqPrime.IsBinaryHeap()) in Unit{})
 	}
 }
 
@@ -92,13 +92,6 @@ pure func (pq PQueue) IsBinaryHeap() bool {
 
 
 type Unit struct{}
-
-ghost
-requires b
-decreases
-pure func asserting(b bool) Unit {
-	return Unit{}
-}
 
 ghost type PQueue = BraunTree
 

--- a/evaluation/experiments/program_proofs_example_10_2/last_half/last_half.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/last_half/last_half.gobra
@@ -20,15 +20,15 @@ pure func (pq PQueue) InsertCorrect(y int) Unit {
 		let max := y < x ? x : y in
 		let _ := r.InsertCorrect(max) in
 		let newRight := r.Insert(max) in
-		let _ := asserting(newRight.Valid()) in
-		let _ := asserting(newRight.IsBalanced()) in
-		let _ := asserting(l.IsBalanced()) in
-		let _ := asserting(
+		asserting (newRight.Valid()) in
+		asserting (newRight.IsBalanced()) in
+		asserting (l.IsBalanced()) in
+		asserting (
 			let Lprime := len(newRight.Elements()) in
 			let Rprime := len(l.Elements()) in
 			Lprime == Rprime || Lprime == Rprime + 1) in
-		let _ := asserting(pqPrime.IsBalanced()) in
-		asserting(pqPrime.IsBinaryHeap())
+		asserting (pqPrime.IsBalanced()) in
+		asserting (pqPrime.IsBinaryHeap()) in Unit{}
 	}
 }
 
@@ -89,13 +89,6 @@ pure func (pq PQueue) IsBinaryHeap() bool {
 
 
 type Unit struct{}
-
-ghost
-requires b
-decreases
-pure func asserting(b bool) Unit {
-	return Unit{}
-}
 
 ghost type PQueue = BraunTree
 

--- a/evaluation/experiments/program_proofs_example_10_2/last_half/last_half.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/last_half/last_half.gobra
@@ -20,15 +20,16 @@ pure func (pq PQueue) InsertCorrect(y int) Unit {
 		let max := y < x ? x : y in
 		let _ := r.InsertCorrect(max) in
 		let newRight := r.Insert(max) in
-		asserting (newRight.Valid()) in
-		asserting (newRight.IsBalanced()) in
-		asserting (l.IsBalanced()) in
+		asserting newRight.Valid() in
+		asserting newRight.IsBalanced() in
+		asserting l.IsBalanced() in
 		asserting (
 			let Lprime := len(newRight.Elements()) in
 			let Rprime := len(l.Elements()) in
 			Lprime == Rprime || Lprime == Rprime + 1) in
-		asserting (pqPrime.IsBalanced()) in
-		asserting (pqPrime.IsBinaryHeap()) in Unit{}
+		asserting pqPrime.IsBalanced() in
+		asserting pqPrime.IsBinaryHeap() in
+		Unit{}
 	}
 }
 

--- a/evaluation/experiments/program_proofs_example_10_2/minimal/minimal.gobra
+++ b/evaluation/experiments/program_proofs_example_10_2/minimal/minimal.gobra
@@ -77,13 +77,6 @@ pure func (pq PQueue) IsBinaryHeap() bool {
 
 type Unit struct{}
 
-ghost
-requires b
-decreases
-pure func asserting(b bool) Unit {
-	return Unit{}
-}
-
 ghost type PQueue = BraunTree
 
 ghost type BraunTree adt {

--- a/evaluation/experiments/standard_library/dicts_not_opaque/dicts_not_opaque.gobra
+++ b/evaluation/experiments/standard_library/dicts_not_opaque/dicts_not_opaque.gobra
@@ -69,7 +69,7 @@ ensures !(k elem domain(d)) ==> len(result) == len(d)
 decreases
 pure func Remove(d dict[int]int, k int) (result dict[int]int) {
 	return let ys := (sets_not_opaque.Remove(domain(d), k)) in
-		asserting (ys intersection domain(d) == ys) in
+		asserting ys intersection domain(d) == ys in
 		RemoveKeys(d, sets_not_opaque.SingletonSet(k))
 }
 
@@ -412,7 +412,8 @@ decreases
 pure func RemoveOccurrences(d dict[int]int, k int) util.Unit {
 	return let ks1 := reveal Keys(d, d[k]) in
 	let ks2 := reveal Keys(Remove(d, k), d[k]) in
-	asserting (ks2 == sets_not_opaque.Remove(ks1, k)) in util.Unit{}
+	asserting ks2 == sets_not_opaque.Remove(ks1, k) in
+	util.Unit{}
 }
 
 // Adding a new key-value pair increases the occurrence of the value by one.
@@ -423,7 +424,8 @@ decreases
 pure func AddOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1 := reveal Keys(d, v) in
 		let ks2 := reveal Keys(d[k = v], v) in
-		asserting (ks2 == sets_not_opaque.Add(ks1, k)) in util.Unit{}
+		asserting ks2 == sets_not_opaque.Add(ks1, k) in
+		util.Unit{}
 }
 
 // Updating a key to a new value results in an additional occurrences for the
@@ -437,10 +439,11 @@ decreases
 pure func UpdateOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1v := reveal Keys(d, v) in
 		let ks2v := reveal Keys(d[k = v], v) in
-		asserting (ks2v == sets_not_opaque.Add(ks1v, k)) in
+		asserting ks2v == sets_not_opaque.Add(ks1v, k) in
 		let ks1dk := reveal Keys(d, d[k]) in
 		let ks2dk := reveal Keys(d[k = v], d[k]) in
-		asserting (ks2dk == sets_not_opaque.Remove(ks1dk, k)) in util.Unit{}
+		asserting ks2dk == sets_not_opaque.Remove(ks1dk, k) in
+		util.Unit{}
 }
 
 // v can occur at most once as a value in injective dictionaries.

--- a/evaluation/experiments/standard_library/dicts_not_opaque/dicts_not_opaque.gobra
+++ b/evaluation/experiments/standard_library/dicts_not_opaque/dicts_not_opaque.gobra
@@ -69,7 +69,7 @@ ensures !(k elem domain(d)) ==> len(result) == len(d)
 decreases
 pure func Remove(d dict[int]int, k int) (result dict[int]int) {
 	return let ys := (sets_not_opaque.Remove(domain(d), k)) in
-		let _ := util.Asserting(ys intersection domain(d) == ys) in
+		asserting (ys intersection domain(d) == ys) in
 		RemoveKeys(d, sets_not_opaque.SingletonSet(k))
 }
 
@@ -412,7 +412,7 @@ decreases
 pure func RemoveOccurrences(d dict[int]int, k int) util.Unit {
 	return let ks1 := reveal Keys(d, d[k]) in
 	let ks2 := reveal Keys(Remove(d, k), d[k]) in
-	util.Asserting(ks2 == sets_not_opaque.Remove(ks1, k))
+	asserting (ks2 == sets_not_opaque.Remove(ks1, k)) in util.Unit{}
 }
 
 // Adding a new key-value pair increases the occurrence of the value by one.
@@ -423,7 +423,7 @@ decreases
 pure func AddOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1 := reveal Keys(d, v) in
 		let ks2 := reveal Keys(d[k = v], v) in
-		util.Asserting(ks2 == sets_not_opaque.Add(ks1, k))
+		asserting (ks2 == sets_not_opaque.Add(ks1, k)) in util.Unit{}
 }
 
 // Updating a key to a new value results in an additional occurrences for the
@@ -437,10 +437,10 @@ decreases
 pure func UpdateOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1v := reveal Keys(d, v) in
 		let ks2v := reveal Keys(d[k = v], v) in
-		let _ := util.Asserting(ks2v == sets_not_opaque.Add(ks1v, k)) in
+		asserting (ks2v == sets_not_opaque.Add(ks1v, k)) in
 		let ks1dk := reveal Keys(d, d[k]) in
 		let ks2dk := reveal Keys(d[k = v], d[k]) in
-		util.Asserting(ks2dk == sets_not_opaque.Remove(ks1dk, k))
+		asserting (ks2dk == sets_not_opaque.Remove(ks1dk, k)) in util.Unit{}
 }
 
 // v can occur at most once as a value in injective dictionaries.

--- a/evaluation/experiments/standard_library/dicts_opaque/dicts_opaque.gobra
+++ b/evaluation/experiments/standard_library/dicts_opaque/dicts_opaque.gobra
@@ -68,7 +68,7 @@ ensures !(k elem domain(d)) ==> len(result) == len(d)
 decreases
 pure func Remove(d dict[int]int, k int) (result dict[int]int) {
 	return let ys := (sets_opaque.Remove(domain(d), k)) in
-		let _ := util.Asserting(ys intersection domain(d) == ys) in
+		asserting (ys intersection domain(d) == ys) in
 		RemoveKeys(d, sets_opaque.SingletonSet(k))
 }
 
@@ -433,7 +433,7 @@ decreases
 pure func RemoveOccurrences(d dict[int]int, k int) util.Unit {
 	return let ks1 := reveal Keys(d, d[k]) in
 	let ks2 := reveal Keys(Remove(d, k), d[k]) in
-	util.Asserting(ks2 == sets_opaque.Remove(ks1, k))
+	asserting (ks2 == sets_opaque.Remove(ks1, k)) in util.Unit{}
 }
 
 // Adding a new key-value pair increases the occurrence of the value by one.
@@ -445,7 +445,7 @@ decreases
 pure func AddOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1 := reveal Keys(d, v) in
 		let ks2 := reveal Keys(d[k = v], v) in
-		util.Asserting(ks2 == sets_opaque.Add(ks1, k))
+		asserting (ks2 == sets_opaque.Add(ks1, k)) in util.Unit{}
 }
 
 // Updating a key to a new value results in an additional occurrences for the
@@ -460,10 +460,10 @@ decreases
 pure func UpdateOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1v := reveal Keys(d, v) in
 		let ks2v := reveal Keys(d[k = v], v) in
-		let _ := util.Asserting(ks2v == sets_opaque.Add(ks1v, k)) in
+		asserting (ks2v == sets_opaque.Add(ks1v, k)) in
 		let ks1dk := reveal Keys(d, d[k]) in
 		let ks2dk := reveal Keys(d[k = v], d[k]) in
-		util.Asserting(ks2dk == sets_opaque.Remove(ks1dk, k))
+		asserting (ks2dk == sets_opaque.Remove(ks1dk, k)) in util.Unit{}
 }
 
 // v can occur at most once as a value in injective dictionaries.

--- a/evaluation/experiments/standard_library/dicts_opaque/dicts_opaque.gobra
+++ b/evaluation/experiments/standard_library/dicts_opaque/dicts_opaque.gobra
@@ -68,7 +68,7 @@ ensures !(k elem domain(d)) ==> len(result) == len(d)
 decreases
 pure func Remove(d dict[int]int, k int) (result dict[int]int) {
 	return let ys := (sets_opaque.Remove(domain(d), k)) in
-		asserting (ys intersection domain(d) == ys) in
+		asserting ys intersection domain(d) == ys in
 		RemoveKeys(d, sets_opaque.SingletonSet(k))
 }
 
@@ -433,7 +433,8 @@ decreases
 pure func RemoveOccurrences(d dict[int]int, k int) util.Unit {
 	return let ks1 := reveal Keys(d, d[k]) in
 	let ks2 := reveal Keys(Remove(d, k), d[k]) in
-	asserting (ks2 == sets_opaque.Remove(ks1, k)) in util.Unit{}
+	asserting ks2 == sets_opaque.Remove(ks1, k) in
+	util.Unit{}
 }
 
 // Adding a new key-value pair increases the occurrence of the value by one.
@@ -445,7 +446,8 @@ decreases
 pure func AddOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1 := reveal Keys(d, v) in
 		let ks2 := reveal Keys(d[k = v], v) in
-		asserting (ks2 == sets_opaque.Add(ks1, k)) in util.Unit{}
+		asserting ks2 == sets_opaque.Add(ks1, k) in
+		util.Unit{}
 }
 
 // Updating a key to a new value results in an additional occurrences for the
@@ -460,10 +462,11 @@ decreases
 pure func UpdateOccurrences(d dict[int]int, k, v int) util.Unit {
 	return let ks1v := reveal Keys(d, v) in
 		let ks2v := reveal Keys(d[k = v], v) in
-		asserting (ks2v == sets_opaque.Add(ks1v, k)) in
+		asserting ks2v == sets_opaque.Add(ks1v, k) in
 		let ks1dk := reveal Keys(d, d[k]) in
 		let ks2dk := reveal Keys(d[k = v], d[k]) in
-		asserting (ks2dk == sets_opaque.Remove(ks1dk, k)) in util.Unit{}
+		asserting ks2dk == sets_opaque.Remove(ks1dk, k) in
+		util.Unit{}
 }
 
 // v can occur at most once as a value in injective dictionaries.

--- a/evaluation/experiments/standard_library/lemma_not_opaque/lemma_not_opaque.gobra
+++ b/evaluation/experiments/standard_library/lemma_not_opaque/lemma_not_opaque.gobra
@@ -66,7 +66,7 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return util.Asserting(len(ys setminus xs) == len(ys) - len(xs))
+	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
 }
 
 // If xs is a subset of ys, then the cardinality of xs is less than or equal to the cardinality of ys.

--- a/evaluation/experiments/standard_library/lemma_not_opaque/lemma_not_opaque.gobra
+++ b/evaluation/experiments/standard_library/lemma_not_opaque/lemma_not_opaque.gobra
@@ -66,7 +66,8 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
+	return asserting len(ys setminus xs) == len(ys) - len(xs) in
+	util.Unit{}
 }
 
 // If xs is a subset of ys, then the cardinality of xs is less than or equal to the cardinality of ys.

--- a/evaluation/experiments/standard_library/lemma_opaque/lemma_opaque.gobra
+++ b/evaluation/experiments/standard_library/lemma_opaque/lemma_opaque.gobra
@@ -68,7 +68,8 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
+	return asserting len(ys setminus xs) == len(ys) - len(xs) in
+	util.Unit{}
 }
 
 // If xs is a subset of ys, then the cardinality of xs is less than or equal to the cardinality of ys.

--- a/evaluation/experiments/standard_library/lemma_opaque/lemma_opaque.gobra
+++ b/evaluation/experiments/standard_library/lemma_opaque/lemma_opaque.gobra
@@ -68,7 +68,7 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return util.Asserting(len(ys setminus xs) == len(ys) - len(xs))
+	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
 }
 
 // If xs is a subset of ys, then the cardinality of xs is less than or equal to the cardinality of ys.

--- a/evaluation/experiments/standard_library/sets_not_opaque/sets_not_opaque.gobra
+++ b/evaluation/experiments/standard_library/sets_not_opaque/sets_not_opaque.gobra
@@ -171,7 +171,8 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
+	return asserting len(ys setminus xs) == len(ys) - len(xs) in
+	util.Unit{}
 }
 
 // Returns whether xs is a proper subset of ys.
@@ -387,8 +388,8 @@ pure func UnionLenLower(xs, ys set[int]) util.Unit {
 		(let yr := Remove(ys, y) in
 		(y elem xs ?
 			(let xr := Remove(xs, y) in
-			(asserting (xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(asserting (xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(asserting xr union yr == Remove(xs union ys, y) in UnionLenLower(xr, yr))) :
+			(asserting xs union yr == Remove(xs union ys, y) in UnionLenLower(xs, yr))))
 }
 
 // The cardinality of a union of two sets is less than or equal to the cardinality of
@@ -408,7 +409,7 @@ decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) util.Unit {
 	return IsEmpty(xs) ? util.Unit{} :
 		let x := Choose(xs) in
-		(asserting ((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(asserting (Remove(xs, x)) intersection ys == Remove((xs intersection ys), x) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 

--- a/evaluation/experiments/standard_library/sets_not_opaque/sets_not_opaque.gobra
+++ b/evaluation/experiments/standard_library/sets_not_opaque/sets_not_opaque.gobra
@@ -171,7 +171,7 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return util.Asserting(len(ys setminus xs) == len(ys) - len(xs))
+	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
 }
 
 // Returns whether xs is a proper subset of ys.
@@ -387,8 +387,8 @@ pure func UnionLenLower(xs, ys set[int]) util.Unit {
 		(let yr := Remove(ys, y) in
 		(y elem xs ?
 			(let xr := Remove(xs, y) in
-			(let _ := util.Asserting(xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(let _ := util.Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(asserting (xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
+			(asserting (xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
 }
 
 // The cardinality of a union of two sets is less than or equal to the cardinality of
@@ -408,7 +408,7 @@ decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) util.Unit {
 	return IsEmpty(xs) ? util.Unit{} :
 		let x := Choose(xs) in
-		(let _ := util.Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(asserting ((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 

--- a/evaluation/experiments/standard_library/sets_opaque/sets_opaque.gobra
+++ b/evaluation/experiments/standard_library/sets_opaque/sets_opaque.gobra
@@ -181,7 +181,8 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
+	return asserting len(ys setminus xs) == len(ys) - len(xs) in
+	util.Unit{}
 }
 
 // Returns whether xs is a proper subset of ys.
@@ -417,8 +418,8 @@ pure func UnionLenLower(xs, ys set[int]) util.Unit {
 		(let yr := Remove(ys, y) in
 		(y elem xs ?
 			(let xr := Remove(xs, y) in
-			(asserting (xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(asserting (xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(asserting xr union yr == Remove(xs union ys, y) in UnionLenLower(xr, yr))) :
+			(asserting xs union yr == Remove(xs union ys, y) in UnionLenLower(xs, yr))))
 }
 
 // The cardinality of a union of two sets is less than or equal to the cardinality of
@@ -440,7 +441,7 @@ decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) util.Unit {
 	return IsEmpty(xs) ? util.Unit{} :
 		let x := Choose(xs) in
-		(asserting ((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(asserting (Remove(xs, x)) intersection ys == Remove((xs intersection ys), x) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 

--- a/evaluation/experiments/standard_library/sets_opaque/sets_opaque.gobra
+++ b/evaluation/experiments/standard_library/sets_opaque/sets_opaque.gobra
@@ -181,7 +181,7 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return util.Asserting(len(ys setminus xs) == len(ys) - len(xs))
+	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
 }
 
 // Returns whether xs is a proper subset of ys.
@@ -417,8 +417,8 @@ pure func UnionLenLower(xs, ys set[int]) util.Unit {
 		(let yr := Remove(ys, y) in
 		(y elem xs ?
 			(let xr := Remove(xs, y) in
-			(let _ := util.Asserting(xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(let _ := util.Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(asserting (xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
+			(asserting (xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
 }
 
 // The cardinality of a union of two sets is less than or equal to the cardinality of
@@ -440,7 +440,7 @@ decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) util.Unit {
 	return IsEmpty(xs) ? util.Unit{} :
 		let x := Choose(xs) in
-		(let _ := util.Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(asserting ((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 

--- a/evaluation/experiments/standard_library/util/util.gobra
+++ b/evaluation/experiments/standard_library/util/util.gobra
@@ -36,9 +36,3 @@ ensures false
 decreases
 func TODO()
 
-ghost
-requires b
-decreases
-pure func Asserting(ghost b bool) Unit {
-	return Unit{}
-}

--- a/refinementguard/lii.gobra
+++ b/refinementguard/lii.gobra
@@ -61,10 +61,10 @@ pure func InstantiateLII(i LII) Unit {
 		unfolding Own()                in
 		unfolding GuardR(i.Guard())    in
 		let trace := traces[i.Guard()] in
-		asserting (i.Guard() elem EG.Guards()) in
-		asserting (guardCompatibleWithState(TS, EG, i.Guard(), LastObservedState(i.Guard()), s, trace)) in
-		asserting (0 < len(trace)) in
-		asserting (trace[len(trace) - 1].s === cs) in
+		asserting i.Guard() elem EG.Guards() in
+		asserting guardCompatibleWithState(TS, EG, i.Guard(), LastObservedState(i.Guard()), s, trace) in
+		asserting 0 < len(trace) in
+		asserting trace[len(trace) - 1].s === cs in
 		instantiateLIIAux(i, traces[i.Guard()], 0)
 }
 
@@ -90,7 +90,7 @@ pure func instantiateLIIAux(i LII, trace seq[traceEntry], currIdx int) Unit {
 		(currIdx == len(trace) - 1 ?
 			Unit{} :
 			let _ := i.PreservedByTransitionsExcept(trace[currIdx].s, get(trace[currIdx+1].e)) in
-			asserting (TS.Update(trace[currIdx].s, get(trace[currIdx+1].e)) === trace[currIdx+1].s) in
-			asserting (i.Prop(trace[currIdx+1].s)) in
+			asserting TS.Update(trace[currIdx].s, get(trace[currIdx+1].e)) === trace[currIdx+1].s in
+			asserting i.Prop(trace[currIdx+1].s) in
 			instantiateLIIAux(i, trace, currIdx+1))
 }

--- a/refinementguard/lii.gobra
+++ b/refinementguard/lii.gobra
@@ -61,10 +61,10 @@ pure func InstantiateLII(i LII) Unit {
 		unfolding Own()                in
 		unfolding GuardR(i.Guard())    in
 		let trace := traces[i.Guard()] in
-		let _ := Asserting(i.Guard() elem EG.Guards()) in
-		let _ := Asserting(guardCompatibleWithState(TS, EG, i.Guard(), LastObservedState(i.Guard()), s, trace)) in
-		let _ := Asserting(0 < len(trace)) in
-		let _ := Asserting(trace[len(trace) - 1].s === cs) in
+		asserting (i.Guard() elem EG.Guards()) in
+		asserting (guardCompatibleWithState(TS, EG, i.Guard(), LastObservedState(i.Guard()), s, trace)) in
+		asserting (0 < len(trace)) in
+		asserting (trace[len(trace) - 1].s === cs) in
 		instantiateLIIAux(i, traces[i.Guard()], 0)
 }
 
@@ -90,7 +90,7 @@ pure func instantiateLIIAux(i LII, trace seq[traceEntry], currIdx int) Unit {
 		(currIdx == len(trace) - 1 ?
 			Unit{} :
 			let _ := i.PreservedByTransitionsExcept(trace[currIdx].s, get(trace[currIdx+1].e)) in
-			let _ := Asserting(TS.Update(trace[currIdx].s, get(trace[currIdx+1].e)) === trace[currIdx+1].s) in
-			let _ := Asserting(i.Prop(trace[currIdx+1].s)) in
+			asserting (TS.Update(trace[currIdx].s, get(trace[currIdx+1].e)) === trace[currIdx+1].s) in
+			asserting (i.Prop(trace[currIdx+1].s)) in
 			instantiateLIIAux(i, trace, currIdx+1))
 }

--- a/refinementguard/util.gobra
+++ b/refinementguard/util.gobra
@@ -18,9 +18,3 @@ package refinementguard
 
 type Unit struct{}
 
-ghost
-requires b
-decreases
-pure func Asserting(b bool) Unit {
-	return Unit{}
-}

--- a/resalgebra/loc.gobra
+++ b/resalgebra/loc.gobra
@@ -634,18 +634,18 @@ ensures  ra.IsElem(ra.Compose(e3, e2))
 ensures  ra.IsValid(ra.Compose(e3, e2))
 decreases
 pure func updateFrameLemma(ra RA, e1 Elem, e2 Elem, e3 Elem) Unit {
-	return let _ := asserting(ra.IsValid(ra.Compose(e1, e2)))   in
-		let _ := asserting(IsFramePreservingUpdate(ra, e1, e3)) in
-		let _ := asserting(forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { LiftedCompose(ra, some(e2), c) } (c !== none[Elem] ==> ra.IsElem(get(c))) ==>
+	return asserting (ra.IsValid(ra.Compose(e1, e2)))   in
+		asserting (IsFramePreservingUpdate(ra, e1, e3)) in
+		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { LiftedCompose(ra, some(e2), c) } (c !== none[Elem] ==> ra.IsElem(get(c))) ==>
 			(LiftedIsValid(ra, LiftedCompose(ra, some(e1), c)) ==> LiftedIsValid(ra, LiftedCompose(ra, some(e3), c)))) in
-		let _ := asserting(forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { LiftedCompose(ra, some(e2), c) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
+		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { LiftedCompose(ra, some(e2), c) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
 			LiftedIsValid(ra, LiftedCompose(ra, some(e1), c)) === ra.IsValid(ra.Compose(e1, get(c)))) in
-		let _ := asserting(forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { ra.Compose(e3, get(c)) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
+		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { ra.Compose(e3, get(c)) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
 			LiftedIsValid(ra, LiftedCompose(ra, some(e3), c)) === ra.IsValid(ra.Compose(e3, get(c)))) in
-		let _ := asserting(forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { ra.Compose(e3, get(c)) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
+		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { ra.Compose(e3, get(c)) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
 			ra.IsValid(ra.Compose(e1, get(c))) ==> ra.IsValid(ra.Compose(e3, get(c)))) in
 		// the term `get(some(e2))` is used to trigger the previous quantifier
-		let _ := asserting(ra.IsElem(ra.Compose(e3, get(some(e2))))) in
+		asserting (ra.IsElem(ra.Compose(e3, get(some(e2))))) in
 		Unit{}
 }
 

--- a/resalgebra/loc.gobra
+++ b/resalgebra/loc.gobra
@@ -634,8 +634,8 @@ ensures  ra.IsElem(ra.Compose(e3, e2))
 ensures  ra.IsValid(ra.Compose(e3, e2))
 decreases
 pure func updateFrameLemma(ra RA, e1 Elem, e2 Elem, e3 Elem) Unit {
-	return asserting (ra.IsValid(ra.Compose(e1, e2)))   in
-		asserting (IsFramePreservingUpdate(ra, e1, e3)) in
+	return asserting ra.IsValid(ra.Compose(e1, e2))   in
+		asserting IsFramePreservingUpdate(ra, e1, e3) in
 		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { LiftedCompose(ra, some(e2), c) } (c !== none[Elem] ==> ra.IsElem(get(c))) ==>
 			(LiftedIsValid(ra, LiftedCompose(ra, some(e1), c)) ==> LiftedIsValid(ra, LiftedCompose(ra, some(e3), c)))) in
 		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { LiftedCompose(ra, some(e2), c) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
@@ -645,7 +645,7 @@ pure func updateFrameLemma(ra RA, e1 Elem, e2 Elem, e3 Elem) Unit {
 		asserting (forall c option[Elem] :: { LiftedCompose(ra, some(e1), c) } { ra.Compose(e3, get(c)) } (c !== none[Elem] && ra.IsElem(get(c))) ==>
 			ra.IsValid(ra.Compose(e1, get(c))) ==> ra.IsValid(ra.Compose(e3, get(c)))) in
 		// the term `get(some(e2))` is used to trigger the previous quantifier
-		asserting (ra.IsElem(ra.Compose(e3, get(some(e2))))) in
+		asserting ra.IsElem(ra.Compose(e3, get(some(e2)))) in
 		Unit{}
 }
 

--- a/resalgebra/product.gobra
+++ b/resalgebra/product.gobra
@@ -40,12 +40,14 @@ ensures  ProductOfSeq(s1 ++ s2, ra) === ra.Compose(ProductOfSeq(s1, ra), Product
 decreases len(s1)
 pure func ProductOfSeqConcat(s1 seq[Elem], s2 seq[Elem], ra RA) Unit {
 	return len(s1) == 1 ?
-		(asserting ((s1 ++ s2)[1:] === s2) in
-		 asserting (ProductOfSeq(s1, ra) === s1[0]) in Unit{}) :
+		(asserting (s1 ++ s2)[1:] === s2 in
+		 asserting ProductOfSeq(s1, ra) === s1[0] in
+		 Unit{}) :
 		(let _ := ProductOfSeqConcat(s1[1:], s2, ra) in
-		 asserting ((s1 ++ s2)[1:] === s1[1:] ++ s2) in
+		 asserting (s1 ++ s2)[1:] === s1[1:] ++ s2 in
 		 let _ := ra.ComposeAssoc(s1[0], ProductOfSeq(s1[1:], ra), ProductOfSeq(s2, ra)) in
-		 asserting (ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra))) in Unit{})
+		 asserting ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra)) in
+		 Unit{})
 }
 
 // Swap positions k and k+1: ProductOfSeq(s) === ProductOfSeq(swap(s, k)).
@@ -65,27 +67,27 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 		 let rest := s[2:] in
 		 let s2 := s[:0] ++ seq[Elem]{s[1], s[0]} ++ s[2:] in
 		 len(rest) == 0 ?
-			(asserting (s === seq[Elem]{a, b}) in
-			 asserting (s[1:] === seq[Elem]{b}) in
-			 asserting (ProductOfSeq(s[1:], ra) === b) in
-			 asserting (ProductOfSeq(s, ra) === ra.Compose(a, b)) in
-			 asserting (s2 === seq[Elem]{b, a}) in
-			 asserting (s2[1:] === seq[Elem]{a}) in
-			 asserting (ProductOfSeq(s2[1:], ra) === a) in
-			 asserting (ProductOfSeq(s2, ra) === ra.Compose(b, a)) in
+			(asserting s === seq[Elem]{a, b} in
+			 asserting s[1:] === seq[Elem]{b} in
+			 asserting ProductOfSeq(s[1:], ra) === b in
+			 asserting ProductOfSeq(s, ra) === ra.Compose(a, b) in
+			 asserting s2 === seq[Elem]{b, a} in
+			 asserting s2[1:] === seq[Elem]{a} in
+			 asserting ProductOfSeq(s2[1:], ra) === a in
+			 asserting ProductOfSeq(s2, ra) === ra.Compose(b, a) in
 			 ra.ComposeComm(a, b)) :
-			(asserting (s === seq[Elem]{a, b} ++ rest) in
-			 asserting (s[1:] === seq[Elem]{b} ++ rest) in
-			 asserting ((s[1:])[0] === b) in
-			 asserting ((s[1:])[1:] === rest) in
-			 asserting (ProductOfSeq(s[1:], ra) === ra.Compose(b, ProductOfSeq(rest, ra))) in
-			 asserting (ProductOfSeq(s, ra) === ra.Compose(a, ra.Compose(b, ProductOfSeq(rest, ra)))) in
-			 asserting (s2 === seq[Elem]{b, a} ++ rest) in
-			 asserting (s2[1:] === seq[Elem]{a} ++ rest) in
-			 asserting ((s2[1:])[0] === a) in
-			 asserting ((s2[1:])[1:] === rest) in
-			 asserting (ProductOfSeq(s2[1:], ra) === ra.Compose(a, ProductOfSeq(rest, ra))) in
-			 asserting (ProductOfSeq(s2, ra) === ra.Compose(b, ra.Compose(a, ProductOfSeq(rest, ra)))) in
+			(asserting s === seq[Elem]{a, b} ++ rest in
+			 asserting s[1:] === seq[Elem]{b} ++ rest in
+			 asserting (s[1:])[0] === b in
+			 asserting (s[1:])[1:] === rest in
+			 asserting ProductOfSeq(s[1:], ra) === ra.Compose(b, ProductOfSeq(rest, ra)) in
+			 asserting ProductOfSeq(s, ra) === ra.Compose(a, ra.Compose(b, ProductOfSeq(rest, ra))) in
+			 asserting s2 === seq[Elem]{b, a} ++ rest in
+			 asserting s2[1:] === seq[Elem]{a} ++ rest in
+			 asserting (s2[1:])[0] === a in
+			 asserting (s2[1:])[1:] === rest in
+			 asserting ProductOfSeq(s2[1:], ra) === ra.Compose(a, ProductOfSeq(rest, ra)) in
+			 asserting ProductOfSeq(s2, ra) === ra.Compose(b, ra.Compose(a, ProductOfSeq(rest, ra))) in
 			 let _ := ra.ComposeAssoc(a, b, ProductOfSeq(rest, ra)) in
 			 let _ := ra.ComposeAssoc(b, a, ProductOfSeq(rest, ra)) in
 			 ra.ComposeComm(a, b))) :
@@ -93,10 +95,11 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 		 let tail := s[1:] in
 		 let tailSwapped := tail[:k-1] ++ seq[Elem]{tail[k], tail[k-1]} ++ tail[k+1:] in
 		 let sSwapped := s[:k] ++ seq[Elem]{s[k+1], s[k]} ++ s[k+2:] in
-		 asserting (sSwapped[0] === s[0]) in
-		 asserting (sSwapped[1:] === tailSwapped) in
-		 asserting (ProductOfSeq(s, ra) === ra.Compose(s[0], ProductOfSeq(tail, ra))) in
-		 asserting (ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra))) in Unit{})
+		 asserting sSwapped[0] === s[0] in
+		 asserting sSwapped[1:] === tailSwapped in
+		 asserting ProductOfSeq(s, ra) === ra.Compose(s[0], ProductOfSeq(tail, ra)) in
+		 asserting ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra)) in
+		 Unit{})
 }
 
 // Move position k to the front: ProductOfSeq(s) === ProductOfSeq([s[k]] ++ s[:k] ++ s[k+1:]).
@@ -111,16 +114,18 @@ ensures  let s2 := seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] in
 decreases k
 pure func ProductOfSeqMoveFront(s seq[Elem], ra RA, k int) Unit {
 	return k == 0 ?
-		asserting (s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:]) in Unit{} :
+		asserting s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:] in
+		Unit{} :
 		(let _ := AdjacentSwapProduct(s, ra, k - 1) in
 		 let sSwapped := s[:k-1] ++ seq[Elem]{s[k], s[k-1]} ++ s[k+1:] in
 		 let _ := ProductOfSeqMoveFront(sSwapped, ra, k - 1) in
-		 asserting (sSwapped[k-1] === s[k]) in
-		 asserting (sSwapped[:k-1] === s[:k-1]) in
-		 asserting (sSwapped[k:] === seq[Elem]{s[k-1]} ++ s[k+1:]) in
-		 asserting (s[:k] === s[:k-1] ++ seq[Elem]{s[k-1]}) in
-		 asserting (seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
-			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:]) in Unit{})
+		 asserting sSwapped[k-1] === s[k] in
+		 asserting sSwapped[:k-1] === s[:k-1] in
+		 asserting sSwapped[k:] === seq[Elem]{s[k-1]} ++ s[k+1:] in
+		 asserting s[:k] === s[:k-1] ++ seq[Elem]{s[k-1]} in
+		 asserting seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
+			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:] in
+			Unit{})
 }
 
 // Given ProductOfSeq(s) is valid, and three distinct positions p1, p2, p3,
@@ -142,37 +147,38 @@ pure func ExtractThreeValid(s seq[Elem], ra RA, p1 int, p2 int, p3 int) Unit {
 		let sA := seq[Elem]{s[p3]} ++ s[:p3] ++ s[p3+1:] in
 		let qA1 := p1 < p3 ? p1 + 1 : p1 in
 		let qA2 := p2 < p3 ? p2 + 1 : p2 in
-		asserting (sA[qA1] === s[p1]) in
-		asserting (sA[qA2] === s[p2]) in
-		asserting (qA1 != qA2) in
+		asserting sA[qA1] === s[p1] in
+		asserting sA[qA2] === s[p2] in
+		asserting qA1 != qA2 in
 		let _ := ProductOfSeqMoveFront(sA, ra, qA2) in
 		let sB := seq[Elem]{sA[qA2]} ++ sA[:qA2] ++ sA[qA2+1:] in
-		asserting (sB[0] === s[p2]) in
-		asserting (sB[1] === s[p3]) in
+		asserting sB[0] === s[p2] in
+		asserting sB[1] === s[p3] in
 		let qB1 := qA1 < qA2 ? qA1 + 1 : qA1 in
-		asserting (sB[qB1] === s[p1]) in
-		asserting (qB1 >= 2) in
+		asserting sB[qB1] === s[p1] in
+		asserting qB1 >= 2 in
 		let _ := ProductOfSeqMoveFront(sB, ra, qB1) in
 		let sC := seq[Elem]{sB[qB1]} ++ sB[:qB1] ++ sB[qB1+1:] in
-		asserting (sC[0] === s[p1]) in
-		asserting (sC[1] === s[p2]) in
-		asserting (sC[2] === s[p3]) in
+		asserting sC[0] === s[p1] in
+		asserting sC[1] === s[p2] in
+		asserting sC[2] === s[p3] in
 		let sHead := seq[Elem]{s[p1], s[p2], s[p3]} in
-		asserting (sHead[1:] === seq[Elem]{s[p2], s[p3]}) in
-		asserting ((sHead[1:])[0] === s[p2]) in
-		asserting ((sHead[1:])[1:] === seq[Elem]{s[p3]}) in
-		asserting (ProductOfSeq(seq[Elem]{s[p3]}, ra) === s[p3]) in
-		asserting (ProductOfSeq(sHead[1:], ra) === ra.Compose(s[p2], s[p3])) in
-		asserting (ProductOfSeq(sHead, ra) === ra.Compose(s[p1], ra.Compose(s[p2], s[p3]))) in
+		asserting sHead[1:] === seq[Elem]{s[p2], s[p3]} in
+		asserting (sHead[1:])[0] === s[p2] in
+		asserting (sHead[1:])[1:] === seq[Elem]{s[p3]} in
+		asserting ProductOfSeq(seq[Elem]{s[p3]}, ra) === s[p3] in
+		asserting ProductOfSeq(sHead[1:], ra) === ra.Compose(s[p2], s[p3]) in
+		asserting ProductOfSeq(sHead, ra) === ra.Compose(s[p1], ra.Compose(s[p2], s[p3])) in
 		let _ := ra.ComposeAssoc(s[p1], s[p2], s[p3]) in
-		asserting (ProductOfSeq(sHead, ra) === ra.Compose(ra.Compose(s[p1], s[p2]), s[p3])) in
+		asserting ProductOfSeq(sHead, ra) === ra.Compose(ra.Compose(s[p1], s[p2]), s[p3]) in
 		(len(s) == 3 ?
-			asserting (sC === sHead) in Unit{} :
+			asserting sC === sHead in
+			Unit{} :
 			(let sTail := sC[3:] in
-			 asserting (sC === sHead ++ sTail) in
+			 asserting sC === sHead ++ sTail in
 			 let _ := ProductOfSeqConcat(sHead, sTail, ra) in
-			 asserting (ProductOfSeq(sC, ra) ===
-				ra.Compose(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))) in
+			 asserting ProductOfSeq(sC, ra) ===
+				ra.Compose(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra)) in
 			 ra.ValidOp(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))))
 }
 

--- a/resalgebra/product.gobra
+++ b/resalgebra/product.gobra
@@ -40,12 +40,12 @@ ensures  ProductOfSeq(s1 ++ s2, ra) === ra.Compose(ProductOfSeq(s1, ra), Product
 decreases len(s1)
 pure func ProductOfSeqConcat(s1 seq[Elem], s2 seq[Elem], ra RA) Unit {
 	return len(s1) == 1 ?
-		(let _ := asserting((s1 ++ s2)[1:] === s2) in
-		 asserting(ProductOfSeq(s1, ra) === s1[0])) :
+		(asserting ((s1 ++ s2)[1:] === s2) in
+		 asserting (ProductOfSeq(s1, ra) === s1[0]) in Unit{}) :
 		(let _ := ProductOfSeqConcat(s1[1:], s2, ra) in
-		 let _ := asserting((s1 ++ s2)[1:] === s1[1:] ++ s2) in
+		 asserting ((s1 ++ s2)[1:] === s1[1:] ++ s2) in
 		 let _ := ra.ComposeAssoc(s1[0], ProductOfSeq(s1[1:], ra), ProductOfSeq(s2, ra)) in
-		 asserting(ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra))))
+		 asserting (ProductOfSeq(s1, ra) === ra.Compose(s1[0], ProductOfSeq(s1[1:], ra))) in Unit{})
 }
 
 // Swap positions k and k+1: ProductOfSeq(s) === ProductOfSeq(swap(s, k)).
@@ -65,27 +65,27 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 		 let rest := s[2:] in
 		 let s2 := s[:0] ++ seq[Elem]{s[1], s[0]} ++ s[2:] in
 		 len(rest) == 0 ?
-			(let _ := asserting(s === seq[Elem]{a, b}) in
-			 let _ := asserting(s[1:] === seq[Elem]{b}) in
-			 let _ := asserting(ProductOfSeq(s[1:], ra) === b) in
-			 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(a, b)) in
-			 let _ := asserting(s2 === seq[Elem]{b, a}) in
-			 let _ := asserting(s2[1:] === seq[Elem]{a}) in
-			 let _ := asserting(ProductOfSeq(s2[1:], ra) === a) in
-			 let _ := asserting(ProductOfSeq(s2, ra) === ra.Compose(b, a)) in
+			(asserting (s === seq[Elem]{a, b}) in
+			 asserting (s[1:] === seq[Elem]{b}) in
+			 asserting (ProductOfSeq(s[1:], ra) === b) in
+			 asserting (ProductOfSeq(s, ra) === ra.Compose(a, b)) in
+			 asserting (s2 === seq[Elem]{b, a}) in
+			 asserting (s2[1:] === seq[Elem]{a}) in
+			 asserting (ProductOfSeq(s2[1:], ra) === a) in
+			 asserting (ProductOfSeq(s2, ra) === ra.Compose(b, a)) in
 			 ra.ComposeComm(a, b)) :
-			(let _ := asserting(s === seq[Elem]{a, b} ++ rest) in
-			 let _ := asserting(s[1:] === seq[Elem]{b} ++ rest) in
-			 let _ := asserting((s[1:])[0] === b) in
-			 let _ := asserting((s[1:])[1:] === rest) in
-			 let _ := asserting(ProductOfSeq(s[1:], ra) === ra.Compose(b, ProductOfSeq(rest, ra))) in
-			 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(a, ra.Compose(b, ProductOfSeq(rest, ra)))) in
-			 let _ := asserting(s2 === seq[Elem]{b, a} ++ rest) in
-			 let _ := asserting(s2[1:] === seq[Elem]{a} ++ rest) in
-			 let _ := asserting((s2[1:])[0] === a) in
-			 let _ := asserting((s2[1:])[1:] === rest) in
-			 let _ := asserting(ProductOfSeq(s2[1:], ra) === ra.Compose(a, ProductOfSeq(rest, ra))) in
-			 let _ := asserting(ProductOfSeq(s2, ra) === ra.Compose(b, ra.Compose(a, ProductOfSeq(rest, ra)))) in
+			(asserting (s === seq[Elem]{a, b} ++ rest) in
+			 asserting (s[1:] === seq[Elem]{b} ++ rest) in
+			 asserting ((s[1:])[0] === b) in
+			 asserting ((s[1:])[1:] === rest) in
+			 asserting (ProductOfSeq(s[1:], ra) === ra.Compose(b, ProductOfSeq(rest, ra))) in
+			 asserting (ProductOfSeq(s, ra) === ra.Compose(a, ra.Compose(b, ProductOfSeq(rest, ra)))) in
+			 asserting (s2 === seq[Elem]{b, a} ++ rest) in
+			 asserting (s2[1:] === seq[Elem]{a} ++ rest) in
+			 asserting ((s2[1:])[0] === a) in
+			 asserting ((s2[1:])[1:] === rest) in
+			 asserting (ProductOfSeq(s2[1:], ra) === ra.Compose(a, ProductOfSeq(rest, ra))) in
+			 asserting (ProductOfSeq(s2, ra) === ra.Compose(b, ra.Compose(a, ProductOfSeq(rest, ra)))) in
 			 let _ := ra.ComposeAssoc(a, b, ProductOfSeq(rest, ra)) in
 			 let _ := ra.ComposeAssoc(b, a, ProductOfSeq(rest, ra)) in
 			 ra.ComposeComm(a, b))) :
@@ -93,10 +93,10 @@ pure func AdjacentSwapProduct(s seq[Elem], ra RA, k int) Unit {
 		 let tail := s[1:] in
 		 let tailSwapped := tail[:k-1] ++ seq[Elem]{tail[k], tail[k-1]} ++ tail[k+1:] in
 		 let sSwapped := s[:k] ++ seq[Elem]{s[k+1], s[k]} ++ s[k+2:] in
-		 let _ := asserting(sSwapped[0] === s[0]) in
-		 let _ := asserting(sSwapped[1:] === tailSwapped) in
-		 let _ := asserting(ProductOfSeq(s, ra) === ra.Compose(s[0], ProductOfSeq(tail, ra))) in
-		 asserting(ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra))))
+		 asserting (sSwapped[0] === s[0]) in
+		 asserting (sSwapped[1:] === tailSwapped) in
+		 asserting (ProductOfSeq(s, ra) === ra.Compose(s[0], ProductOfSeq(tail, ra))) in
+		 asserting (ProductOfSeq(sSwapped, ra) === ra.Compose(s[0], ProductOfSeq(tailSwapped, ra))) in Unit{})
 }
 
 // Move position k to the front: ProductOfSeq(s) === ProductOfSeq([s[k]] ++ s[:k] ++ s[k+1:]).
@@ -111,16 +111,16 @@ ensures  let s2 := seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] in
 decreases k
 pure func ProductOfSeqMoveFront(s seq[Elem], ra RA, k int) Unit {
 	return k == 0 ?
-		asserting(s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:]) :
+		asserting (s === seq[Elem]{s[0]} ++ s[:0] ++ s[1:]) in Unit{} :
 		(let _ := AdjacentSwapProduct(s, ra, k - 1) in
 		 let sSwapped := s[:k-1] ++ seq[Elem]{s[k], s[k-1]} ++ s[k+1:] in
 		 let _ := ProductOfSeqMoveFront(sSwapped, ra, k - 1) in
-		 let _ := asserting(sSwapped[k-1] === s[k]) in
-		 let _ := asserting(sSwapped[:k-1] === s[:k-1]) in
-		 let _ := asserting(sSwapped[k:] === seq[Elem]{s[k-1]} ++ s[k+1:]) in
-		 let _ := asserting(s[:k] === s[:k-1] ++ seq[Elem]{s[k-1]}) in
-		 asserting(seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
-			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:]))
+		 asserting (sSwapped[k-1] === s[k]) in
+		 asserting (sSwapped[:k-1] === s[:k-1]) in
+		 asserting (sSwapped[k:] === seq[Elem]{s[k-1]} ++ s[k+1:]) in
+		 asserting (s[:k] === s[:k-1] ++ seq[Elem]{s[k-1]}) in
+		 asserting (seq[Elem]{s[k]} ++ s[:k] ++ s[k+1:] ===
+			seq[Elem]{sSwapped[k-1]} ++ sSwapped[:k-1] ++ sSwapped[k:]) in Unit{})
 }
 
 // Given ProductOfSeq(s) is valid, and three distinct positions p1, p2, p3,
@@ -142,36 +142,36 @@ pure func ExtractThreeValid(s seq[Elem], ra RA, p1 int, p2 int, p3 int) Unit {
 		let sA := seq[Elem]{s[p3]} ++ s[:p3] ++ s[p3+1:] in
 		let qA1 := p1 < p3 ? p1 + 1 : p1 in
 		let qA2 := p2 < p3 ? p2 + 1 : p2 in
-		let _ := asserting(sA[qA1] === s[p1]) in
-		let _ := asserting(sA[qA2] === s[p2]) in
-		let _ := asserting(qA1 != qA2) in
+		asserting (sA[qA1] === s[p1]) in
+		asserting (sA[qA2] === s[p2]) in
+		asserting (qA1 != qA2) in
 		let _ := ProductOfSeqMoveFront(sA, ra, qA2) in
 		let sB := seq[Elem]{sA[qA2]} ++ sA[:qA2] ++ sA[qA2+1:] in
-		let _ := asserting(sB[0] === s[p2]) in
-		let _ := asserting(sB[1] === s[p3]) in
+		asserting (sB[0] === s[p2]) in
+		asserting (sB[1] === s[p3]) in
 		let qB1 := qA1 < qA2 ? qA1 + 1 : qA1 in
-		let _ := asserting(sB[qB1] === s[p1]) in
-		let _ := asserting(qB1 >= 2) in
+		asserting (sB[qB1] === s[p1]) in
+		asserting (qB1 >= 2) in
 		let _ := ProductOfSeqMoveFront(sB, ra, qB1) in
 		let sC := seq[Elem]{sB[qB1]} ++ sB[:qB1] ++ sB[qB1+1:] in
-		let _ := asserting(sC[0] === s[p1]) in
-		let _ := asserting(sC[1] === s[p2]) in
-		let _ := asserting(sC[2] === s[p3]) in
+		asserting (sC[0] === s[p1]) in
+		asserting (sC[1] === s[p2]) in
+		asserting (sC[2] === s[p3]) in
 		let sHead := seq[Elem]{s[p1], s[p2], s[p3]} in
-		let _ := asserting(sHead[1:] === seq[Elem]{s[p2], s[p3]}) in
-		let _ := asserting((sHead[1:])[0] === s[p2]) in
-		let _ := asserting((sHead[1:])[1:] === seq[Elem]{s[p3]}) in
-		let _ := asserting(ProductOfSeq(seq[Elem]{s[p3]}, ra) === s[p3]) in
-		let _ := asserting(ProductOfSeq(sHead[1:], ra) === ra.Compose(s[p2], s[p3])) in
-		let _ := asserting(ProductOfSeq(sHead, ra) === ra.Compose(s[p1], ra.Compose(s[p2], s[p3]))) in
+		asserting (sHead[1:] === seq[Elem]{s[p2], s[p3]}) in
+		asserting ((sHead[1:])[0] === s[p2]) in
+		asserting ((sHead[1:])[1:] === seq[Elem]{s[p3]}) in
+		asserting (ProductOfSeq(seq[Elem]{s[p3]}, ra) === s[p3]) in
+		asserting (ProductOfSeq(sHead[1:], ra) === ra.Compose(s[p2], s[p3])) in
+		asserting (ProductOfSeq(sHead, ra) === ra.Compose(s[p1], ra.Compose(s[p2], s[p3]))) in
 		let _ := ra.ComposeAssoc(s[p1], s[p2], s[p3]) in
-		let _ := asserting(ProductOfSeq(sHead, ra) === ra.Compose(ra.Compose(s[p1], s[p2]), s[p3])) in
+		asserting (ProductOfSeq(sHead, ra) === ra.Compose(ra.Compose(s[p1], s[p2]), s[p3])) in
 		(len(s) == 3 ?
-			asserting(sC === sHead) :
+			asserting (sC === sHead) in Unit{} :
 			(let sTail := sC[3:] in
-			 let _ := asserting(sC === sHead ++ sTail) in
+			 asserting (sC === sHead ++ sTail) in
 			 let _ := ProductOfSeqConcat(sHead, sTail, ra) in
-			 let _ := asserting(ProductOfSeq(sC, ra) ===
+			 asserting (ProductOfSeq(sC, ra) ===
 				ra.Compose(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))) in
 			 ra.ValidOp(ProductOfSeq(sHead, ra), ProductOfSeq(sTail, ra))))
 }

--- a/resalgebra/ra.gobra
+++ b/resalgebra/ra.gobra
@@ -103,7 +103,8 @@ ensures  forall e1, e2, e3 Elem :: { ra.Compose(ra.Compose(e1, e2), e3) } { ra.C
 		ra.Compose(ra.Compose(e1, e2), e3) === ra.Compose(e1, ra.Compose(e2, e3))
 decreases
 pure func ComposeAssocQ(ra RA) Unit {
-	return asserting (forall e1, e2, e3 Elem :: { ra.Compose(ra.Compose(e1, e2), e3) } { ra.Compose(e1, ra.Compose(e2, e3)) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsElem(e3) ==> let _ := ra.ComposeAssoc(e1, e2, e3) in ra.Compose(ra.Compose(e1, e2), e3) === ra.Compose(e1, ra.Compose(e2, e3))) in Unit{}
+	return asserting (forall e1, e2, e3 Elem :: { ra.Compose(ra.Compose(e1, e2), e3) } { ra.Compose(e1, ra.Compose(e2, e3)) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsElem(e3) ==> let _ := ra.ComposeAssoc(e1, e2, e3) in ra.Compose(ra.Compose(e1, e2), e3) === ra.Compose(e1, ra.Compose(e2, e3))) in
+	Unit{}
 }
 
 ghost
@@ -113,7 +114,8 @@ ensures  forall e1, e2 Elem :: { ra.Compose(e1, e2) } { ra.Compose(e2, e1) } ra.
 	ra.Compose(e1, e2) === ra.Compose(e2, e1)
 decreases
 pure func ComposeCommQ(ra RA) Unit {
-	return asserting (forall e1, e2 Elem :: { ra.Compose(e1, e2) } { ra.Compose(e2, e1) } ra.IsElem(e1) && ra.IsElem(e2) ==> let _ := ra.ComposeComm(e1, e2) in ra.Compose(e1, e2) === ra.Compose(e2, e1)) in Unit{}
+	return asserting (forall e1, e2 Elem :: { ra.Compose(e1, e2) } { ra.Compose(e2, e1) } ra.IsElem(e1) && ra.IsElem(e2) ==> let _ := ra.ComposeComm(e1, e2) in ra.Compose(e1, e2) === ra.Compose(e2, e1)) in
+	Unit{}
 }
 
 ghost
@@ -124,7 +126,8 @@ ensures  forall e Elem :: { ra.Core(e) } ra.IsElem(e) ==>
 		c !== none[Elem] ==> ra.Compose(get(c), e) === e
 decreases
 pure func CoreIdQ(ra RA) Unit {
-	return asserting (forall e Elem :: { ra.Core(e) } ra.IsElem(e) ==> let _ := ra.CoreId(e) in ra.Core(e) !== none[Elem] ==> ra.Compose(get(ra.Core(e)), e) === e) in Unit{}
+	return asserting (forall e Elem :: { ra.Core(e) } ra.IsElem(e) ==> let _ := ra.CoreId(e) in ra.Core(e) !== none[Elem] ==> ra.Compose(get(ra.Core(e)), e) === e) in
+	Unit{}
 }
 
 ghost
@@ -137,7 +140,8 @@ ensures  forall e Elem :: { ra.Core(e) } ra.IsElem(e) && ra.Core(e) !== none[Ele
 	get(cc) === get(c)
 decreases
 pure func CoreIdemQ(ra RA) Unit {
-	return asserting (forall e Elem :: { ra.Core(e) } ra.IsElem(e) && ra.Core(e) !== none[Elem] ==> let _ := ra.CoreIdem(e) in let c := ra.Core(e) in let cc := ra.Core(get(c)) in cc !== none[Elem] && get(cc) === get(c)) in Unit{}
+	return asserting (forall e Elem :: { ra.Core(e) } ra.IsElem(e) && ra.Core(e) !== none[Elem] ==> let _ := ra.CoreIdem(e) in let c := ra.Core(e) in let cc := ra.Core(get(c)) in cc !== none[Elem] && get(cc) === get(c)) in
+	Unit{}
 }
 
 ghost
@@ -151,7 +155,8 @@ ensures  forall e1, e2 Elem ::  { ra.Core(e1), ra.Core(e2) } ra.IsElem(e1) && ra
 decreases
 pure func CoreMonoQ(ra RA) Unit {
 	return asserting (forall e1, e2 Elem :: { ra.Core(e1), ra.Core(e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.Core(e1) !== none[Elem] && (exists e3 Elem :: { ra.IsElem(e3) } ra.IsElem(e3) && e2 === ra.Compose(e1, e3)) ==> let _ := ra.CoreMono(e1, e2) in ra.Core(e2) !== none[Elem] &&
-	exists e4 Elem :: { ra.IsElem(e4) } ra.IsElem(e4) && get(ra.Core(e2)) === ra.Compose(get(ra.Core(e1)), e4)) in Unit{}
+	exists e4 Elem :: { ra.IsElem(e4) } ra.IsElem(e4) && get(ra.Core(e2)) === ra.Compose(get(ra.Core(e1)), e4)) in
+	Unit{}
 }
 
 ghost
@@ -161,6 +166,7 @@ ensures  forall e1, e2 Elem :: { ra.Compose(e1, e2) } ra.IsElem(e1) && ra.IsElem
 	ra.IsValid(e1)
 decreases
 pure func ValidOpQ(ra RA) Unit {
-	return asserting (forall e1, e2 Elem :: { ra.Compose(e1, e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsValid(ra.Compose(e1, e2)) ==> let _ := ra.ValidOp(e1, e2) in ra.IsValid(e1)) in Unit{}
+	return asserting (forall e1, e2 Elem :: { ra.Compose(e1, e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsValid(ra.Compose(e1, e2)) ==> let _ := ra.ValidOp(e1, e2) in ra.IsValid(e1)) in
+	Unit{}
 }
 

--- a/resalgebra/ra.gobra
+++ b/resalgebra/ra.gobra
@@ -103,7 +103,7 @@ ensures  forall e1, e2, e3 Elem :: { ra.Compose(ra.Compose(e1, e2), e3) } { ra.C
 		ra.Compose(ra.Compose(e1, e2), e3) === ra.Compose(e1, ra.Compose(e2, e3))
 decreases
 pure func ComposeAssocQ(ra RA) Unit {
-	return asserting(forall e1, e2, e3 Elem :: { ra.Compose(ra.Compose(e1, e2), e3) } { ra.Compose(e1, ra.Compose(e2, e3)) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsElem(e3) ==> let _ := ra.ComposeAssoc(e1, e2, e3) in ra.Compose(ra.Compose(e1, e2), e3) === ra.Compose(e1, ra.Compose(e2, e3)))
+	return asserting (forall e1, e2, e3 Elem :: { ra.Compose(ra.Compose(e1, e2), e3) } { ra.Compose(e1, ra.Compose(e2, e3)) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsElem(e3) ==> let _ := ra.ComposeAssoc(e1, e2, e3) in ra.Compose(ra.Compose(e1, e2), e3) === ra.Compose(e1, ra.Compose(e2, e3))) in Unit{}
 }
 
 ghost
@@ -113,7 +113,7 @@ ensures  forall e1, e2 Elem :: { ra.Compose(e1, e2) } { ra.Compose(e2, e1) } ra.
 	ra.Compose(e1, e2) === ra.Compose(e2, e1)
 decreases
 pure func ComposeCommQ(ra RA) Unit {
-	return asserting(forall e1, e2 Elem :: { ra.Compose(e1, e2) } { ra.Compose(e2, e1) } ra.IsElem(e1) && ra.IsElem(e2) ==> let _ := ra.ComposeComm(e1, e2) in ra.Compose(e1, e2) === ra.Compose(e2, e1))
+	return asserting (forall e1, e2 Elem :: { ra.Compose(e1, e2) } { ra.Compose(e2, e1) } ra.IsElem(e1) && ra.IsElem(e2) ==> let _ := ra.ComposeComm(e1, e2) in ra.Compose(e1, e2) === ra.Compose(e2, e1)) in Unit{}
 }
 
 ghost
@@ -124,7 +124,7 @@ ensures  forall e Elem :: { ra.Core(e) } ra.IsElem(e) ==>
 		c !== none[Elem] ==> ra.Compose(get(c), e) === e
 decreases
 pure func CoreIdQ(ra RA) Unit {
-	return asserting(forall e Elem :: { ra.Core(e) } ra.IsElem(e) ==> let _ := ra.CoreId(e) in ra.Core(e) !== none[Elem] ==> ra.Compose(get(ra.Core(e)), e) === e)
+	return asserting (forall e Elem :: { ra.Core(e) } ra.IsElem(e) ==> let _ := ra.CoreId(e) in ra.Core(e) !== none[Elem] ==> ra.Compose(get(ra.Core(e)), e) === e) in Unit{}
 }
 
 ghost
@@ -137,7 +137,7 @@ ensures  forall e Elem :: { ra.Core(e) } ra.IsElem(e) && ra.Core(e) !== none[Ele
 	get(cc) === get(c)
 decreases
 pure func CoreIdemQ(ra RA) Unit {
-	return asserting(forall e Elem :: { ra.Core(e) } ra.IsElem(e) && ra.Core(e) !== none[Elem] ==> let _ := ra.CoreIdem(e) in let c := ra.Core(e) in let cc := ra.Core(get(c)) in cc !== none[Elem] && get(cc) === get(c))
+	return asserting (forall e Elem :: { ra.Core(e) } ra.IsElem(e) && ra.Core(e) !== none[Elem] ==> let _ := ra.CoreIdem(e) in let c := ra.Core(e) in let cc := ra.Core(get(c)) in cc !== none[Elem] && get(cc) === get(c)) in Unit{}
 }
 
 ghost
@@ -150,8 +150,8 @@ ensures  forall e1, e2 Elem ::  { ra.Core(e1), ra.Core(e2) } ra.IsElem(e1) && ra
 	exists e4 Elem :: { ra.IsElem(e4) } ra.IsElem(e4) && get(ra.Core(e2)) === ra.Compose(get(ra.Core(e1)), e4)
 decreases
 pure func CoreMonoQ(ra RA) Unit {
-	return asserting(forall e1, e2 Elem :: { ra.Core(e1), ra.Core(e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.Core(e1) !== none[Elem] && (exists e3 Elem :: { ra.IsElem(e3) } ra.IsElem(e3) && e2 === ra.Compose(e1, e3)) ==> let _ := ra.CoreMono(e1, e2) in ra.Core(e2) !== none[Elem] &&
-	exists e4 Elem :: { ra.IsElem(e4) } ra.IsElem(e4) && get(ra.Core(e2)) === ra.Compose(get(ra.Core(e1)), e4))
+	return asserting (forall e1, e2 Elem :: { ra.Core(e1), ra.Core(e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.Core(e1) !== none[Elem] && (exists e3 Elem :: { ra.IsElem(e3) } ra.IsElem(e3) && e2 === ra.Compose(e1, e3)) ==> let _ := ra.CoreMono(e1, e2) in ra.Core(e2) !== none[Elem] &&
+	exists e4 Elem :: { ra.IsElem(e4) } ra.IsElem(e4) && get(ra.Core(e2)) === ra.Compose(get(ra.Core(e1)), e4)) in Unit{}
 }
 
 ghost
@@ -161,12 +161,6 @@ ensures  forall e1, e2 Elem :: { ra.Compose(e1, e2) } ra.IsElem(e1) && ra.IsElem
 	ra.IsValid(e1)
 decreases
 pure func ValidOpQ(ra RA) Unit {
-	return asserting(forall e1, e2 Elem :: { ra.Compose(e1, e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsValid(ra.Compose(e1, e2)) ==> let _ := ra.ValidOp(e1, e2) in ra.IsValid(e1))
+	return asserting (forall e1, e2 Elem :: { ra.Compose(e1, e2) } ra.IsElem(e1) && ra.IsElem(e2) && ra.IsValid(ra.Compose(e1, e2)) ==> let _ := ra.ValidOp(e1, e2) in ra.IsValid(e1)) in Unit{}
 }
 
-ghost
-requires b
-decreases
-pure func asserting(ghost b bool) Unit {
-	return Unit{}
-}

--- a/seqs/seqs.gobra
+++ b/seqs/seqs.gobra
@@ -373,7 +373,8 @@ requires 0 <= a && a < b && b <= len(xs)
 ensures Max(xs[a:b]) <= Max(xs)
 decreases
 pure func MaxOfSubseq(xs seq[int], a, b int) util.Unit {
-	return asserting (Max(xs[a:b]) elem xs) in util.Unit{}
+	return asserting Max(xs[a:b]) elem xs in
+	util.Unit{}
 }
 
 // The minimum element in a non-empty sequence is less than or equal to the
@@ -383,7 +384,8 @@ requires 0 <= a && a < b && b <= len(xs)
 ensures Min(xs[a:b]) >= Min(xs)
 decreases
 pure func MinOfSubseq(xs seq[int], a, b int) util.Unit {
-	return asserting (Min(xs[a:b]) elem xs) in util.Unit{}
+	return asserting Min(xs[a:b]) elem xs in
+	util.Unit{}
 }
 
 // Flattens a sequence of sequences into a single sequence.
@@ -399,7 +401,7 @@ ensures Flatten(xs ++ ys) == Flatten(xs) ++ Flatten(ys)
 decreases xs
 pure func FlattenConcat(xs, ys seq[seq[int]]) util.Unit {
 	return len(xs) == 0 ? util.Unit{} :
-	asserting ((xs ++ ys)[1:] == xs[1:] ++ ys) in
+	asserting (xs ++ ys)[1:] == xs[1:] ++ ys in
 	FlattenConcat(xs[1:], ys)
 }
 
@@ -410,7 +412,8 @@ decreases
 pure func FlattenSingleton(xs seq[int]) util.Unit {
 	// See https://github.com/viperproject/silicon/issues/803 for an explanation
 	// of this proof.
-	return asserting (Flatten(seq[seq[int]]{xs}[1:]) == Empty()) in util.Unit{}
+	return asserting Flatten(seq[seq[int]]{xs}[1:]) == Empty() in
+	util.Unit{}
 }
 
 // The length of a flattened sequence of sequences xs is greater than or equal

--- a/seqs/seqs.gobra
+++ b/seqs/seqs.gobra
@@ -373,7 +373,7 @@ requires 0 <= a && a < b && b <= len(xs)
 ensures Max(xs[a:b]) <= Max(xs)
 decreases
 pure func MaxOfSubseq(xs seq[int], a, b int) util.Unit {
-	return util.Asserting(Max(xs[a:b]) elem xs)
+	return asserting (Max(xs[a:b]) elem xs) in util.Unit{}
 }
 
 // The minimum element in a non-empty sequence is less than or equal to the
@@ -383,7 +383,7 @@ requires 0 <= a && a < b && b <= len(xs)
 ensures Min(xs[a:b]) >= Min(xs)
 decreases
 pure func MinOfSubseq(xs seq[int], a, b int) util.Unit {
-	return util.Asserting(Min(xs[a:b]) elem xs)
+	return asserting (Min(xs[a:b]) elem xs) in util.Unit{}
 }
 
 // Flattens a sequence of sequences into a single sequence.
@@ -399,7 +399,7 @@ ensures Flatten(xs ++ ys) == Flatten(xs) ++ Flatten(ys)
 decreases xs
 pure func FlattenConcat(xs, ys seq[seq[int]]) util.Unit {
 	return len(xs) == 0 ? util.Unit{} :
-	let _ := util.Asserting((xs ++ ys)[1:] == xs[1:] ++ ys) in
+	asserting ((xs ++ ys)[1:] == xs[1:] ++ ys) in
 	FlattenConcat(xs[1:], ys)
 }
 
@@ -410,7 +410,7 @@ decreases
 pure func FlattenSingleton(xs seq[int]) util.Unit {
 	// See https://github.com/viperproject/silicon/issues/803 for an explanation
 	// of this proof.
-	return util.Asserting(Flatten(seq[seq[int]]{xs}[1:]) == Empty())
+	return asserting (Flatten(seq[seq[int]]{xs}[1:]) == Empty()) in util.Unit{}
 }
 
 // The length of a flattened sequence of sequences xs is greater than or equal

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -177,7 +177,8 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
+	return asserting len(ys setminus xs) == len(ys) - len(xs) in
+	util.Unit{}
 }
 
 // Returns whether xs is a proper subset of ys.
@@ -393,8 +394,8 @@ pure func UnionLenLower(xs, ys set[int]) util.Unit {
 		(let yr := Remove(ys, y) in
 		(y elem xs ?
 			(let xr := Remove(xs, y) in
-			(asserting (xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(asserting (xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(asserting xr union yr == Remove(xs union ys, y) in UnionLenLower(xr, yr))) :
+			(asserting xs union yr == Remove(xs union ys, y) in UnionLenLower(xs, yr))))
 }
 
 // The cardinality of a union of two sets is less than or equal to the cardinality of
@@ -414,7 +415,7 @@ decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) util.Unit {
 	return IsEmpty(xs) ? util.Unit{} :
 		let x := Choose(xs) in
-		(asserting ((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(asserting (Remove(xs, x)) intersection ys == Remove((xs intersection ys), x) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 

--- a/sets/sets.gobra
+++ b/sets/sets.gobra
@@ -177,7 +177,7 @@ requires len(xs) == len(ys)
 ensures xs == ys
 decreases
 pure func SubsetEquality(xs, ys set[int]) util.Unit {
-	return util.Asserting(len(ys setminus xs) == len(ys) - len(xs))
+	return asserting (len(ys setminus xs) == len(ys) - len(xs)) in util.Unit{}
 }
 
 // Returns whether xs is a proper subset of ys.
@@ -393,8 +393,8 @@ pure func UnionLenLower(xs, ys set[int]) util.Unit {
 		(let yr := Remove(ys, y) in
 		(y elem xs ?
 			(let xr := Remove(xs, y) in
-			(let _ := util.Asserting(xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
-			(let _ := util.Asserting(xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
+			(asserting (xr union yr == Remove(xs union ys, y)) in UnionLenLower(xr, yr))) :
+			(asserting (xs union yr == Remove(xs union ys, y)) in UnionLenLower(xs, yr))))
 }
 
 // The cardinality of a union of two sets is less than or equal to the cardinality of
@@ -414,7 +414,7 @@ decreases xs
 pure func IntersectLenUpper(xs, ys set[int]) util.Unit {
 	return IsEmpty(xs) ? util.Unit{} :
 		let x := Choose(xs) in
-		(let _ := util.Asserting((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
+		(asserting ((Remove(xs, x)) intersection ys == Remove((xs intersection ys), x)) in
 		(IntersectLenUpper(Remove(xs, x), ys)))
 }
 

--- a/util/util.gobra
+++ b/util/util.gobra
@@ -44,11 +44,3 @@ ensures false
 decreases
 func TODO()
 
-// Deprecated! `Assert` and the type `Lemma` should be used for the purposes
-// for which we previously used `Asserting` and `Unit`.
-ghost
-requires b
-decreases
-pure func Asserting(ghost b bool) Unit {
-	return Unit{}
-}


### PR DESCRIPTION
## Summary

This PR refactors the `asserting`/`Asserting` helper functions across the codebase to use Gobra's `in` expression syntax instead of `let` bindings, and removes the now-redundant function definitions from utility modules.

## Key Changes

- **Syntax modernization**: Converted all `asserting(condition)` calls from `let _ := asserting(...)` patterns to `asserting (...) in` expressions, which is more idiomatic in Gobra
- **Return type consistency**: Added explicit `in Unit{}` returns where needed to ensure proper type alignment with the new syntax
- **Function removal**: Deleted deprecated `asserting`/`Asserting` function definitions from:
  - `util/util.gobra`
  - `evaluation/experiments/standard_library/util/util.gobra`
  - `refinementguard/util.gobra`
  - Multiple program proof example files (`full.gobra`, `last_half.gobra`, `first_half.gobra`, `minimal.gobra`)
  
- **Whitespace normalization**: Added consistent spacing around `asserting` calls (e.g., `asserting (...)` instead of `asserting(...)`)

## Files Modified

- `resalgebra/product.gobra` - Multiple asserting calls refactored
- `resalgebra/ra.gobra` - Asserting calls in query functions updated
- `resalgebra/loc.gobra` - Frame lemma asserting calls refactored
- `refinementguard/lii.gobra` - Asserting calls converted to `in` syntax
- `dicts/dicts.gobra` - Dictionary operation asserting calls updated
- `seqs/seqs.gobra` - Sequence operation asserting calls updated
- `sets/sets.gobra` - Set operation asserting calls updated
- Multiple evaluation/experiments files with similar refactoring
- Utility modules with function definition removals

## Implementation Details

The refactoring maintains semantic equivalence while improving code clarity. The `in` syntax is more explicit about the scope and sequencing of assertions within proof expressions, making the code easier to read and maintain.

https://claude.ai/code/session_01PwdWmKZjxyysaGtdgYU5La