### PR TITLE
Reimplement View on top of the built-in slice-to-sequence conversion

### DIFF
--- a/byteslice/byteslice.gobra
+++ b/byteslice/byteslice.gobra
@@ -33,6 +33,18 @@ func Byte(s []byte, start int, end int, i int) byte {
 	return unfolding acc(Bytes(s, start, end), _) in s[i]
 }
 
+// View returns the sequence of bytes stored in ub.
+ghost
+requires Bytes(ub, 0, len(ub))
+ensures  len(res) == len(ub)
+ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+    res[i] == Byte(ub, 0, len(ub), i)
+decreases
+opaque
+pure func View(ub []byte) (res seq[byte]) {
+	return unfolding Bytes(ub, 0, len(ub)) in seq(ub)
+}
+
 ghost
 requires 0 < p
 requires acc(Bytes(s, start, end), p)

--- a/byteslice/byteslice.gobra
+++ b/byteslice/byteslice.gobra
@@ -34,26 +34,6 @@ func Byte(s []byte, start int, end int, i int) byte {
 }
 
 ghost
-requires acc(Bytes(ub, 0, len(ub)), _)
-ensures  len(res) == len(ub)
-ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
-    res[i] == Byte(ub, 0, len(ub), i)
-decreases
-opaque
-pure func View(ub []byte) (res seq[byte]) {
-	return unfolding acc(Bytes(ub, 0, len(ub)), _) in ViewInner(ub)
-}
-
-ghost
-requires forall i int :: { &ub[i] } 0 <= i && i < len(ub) ==> acc(&ub[i], _)
-ensures  len(res) == len(ub)
-ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==> res[i] == ub[i]
-decreases len(ub)
-pure func ViewInner(ub []byte) (res seq[byte]) {
-	return len(ub) == 0 ? seq[byte]{} :  ViewInner(ub[:len(ub)-1]) ++ seq[byte]{ub[len(ub)-1]}
-}
-
-ghost
 requires 0 < p
 requires acc(Bytes(s, start, end), p)
 requires start <= idx && idx <= end

--- a/runeslice/runeslice.gobra
+++ b/runeslice/runeslice.gobra
@@ -33,6 +33,18 @@ func Rune(s []rune, start int, end int, i int) rune {
 	return unfolding acc(Runes(s, start, end), _) in s[i]
 }
 
+// View returns the sequence of runes stored in ub.
+ghost
+requires Runes(ub, 0, len(ub))
+ensures  len(res) == len(ub)
+ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
+    res[i] == Rune(ub, 0, len(ub), i)
+decreases
+opaque
+pure func View(ub []rune) (res seq[rune]) {
+	return unfolding Runes(ub, 0, len(ub)) in seq(ub)
+}
+
 ghost
 requires 0 < p
 requires acc(Runes(s, start, end), p)

--- a/runeslice/runeslice.gobra
+++ b/runeslice/runeslice.gobra
@@ -34,26 +34,6 @@ func Rune(s []rune, start int, end int, i int) rune {
 }
 
 ghost
-requires acc(Runes(ub, 0, len(ub)), _)
-ensures  len(res) == len(ub)
-ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==>
-    res[i] == Rune(ub, 0, len(ub), i)
-decreases
-opaque
-pure func View(ub []rune) (res seq[rune]) {
-	return unfolding acc(Runes(ub, 0, len(ub)), _) in ViewInner(ub)
-}
-
-ghost
-requires forall i int :: { &ub[i] } 0 <= i && i < len(ub) ==> acc(&ub[i], _)
-ensures  len(res) == len(ub)
-ensures  forall i int :: { res[i] } 0 <= i && i < len(ub) ==> res[i] == ub[i]
-decreases len(ub)
-pure func ViewInner(ub []rune) (res seq[rune]) {
-	return len(ub) == 0 ? seq[rune]{} :  ViewInner(ub[:len(ub)-1]) ++ seq[rune]{ub[len(ub)-1]}
-}
-
-ghost
 requires 0 < p
 requires acc(Runes(s, start, end), p)
 requires start <= idx && idx <= end


### PR DESCRIPTION
## Summary

Gobra now supports converting slices and arrays to sequences directly (viperproject/gobra#1088), so the hand-written converters in this repo are redundant.

`ViewInner` — the recursive slice-to-sequence converter in `byteslice` and `runeslice` — is removed. `View` is kept in both packages, but reimplemented as a thin `opaque` wrapper over the built-in `seq()` conversion.

## Changes

- **byteslice/byteslice.gobra**: removed `ViewInner()`; `View()` is now `unfolding Bytes(ub, 0, len(ub)) in seq(ub)`
- **runeslice/runeslice.gobra**: removed `ViewInner()`; `View()` is now `unfolding Runes(ub, 0, len(ub)) in seq(ub)`

`View` keeps its previous postconditions (`len(res) == len(ub)` and the pointwise `res[i] == Byte(...)` / `res[i] == Rune(...)`), so clients see the same spec. Its precondition now takes the full `Bytes`/`Runes` resource instead of a wildcard.

The `Byte()` and `Rune()` accessors and all the split/combine/reslice lemmas are unchanged.

## Notes

- No array-to-sequence converters existed in this repo, so there were none to remove.
- Requiring the full resource in `View` is a breaking change for downstream callers holding only fractional permission. Nothing in this repo calls `View`, so there were no call sites to update.

https://claude.ai/code/session_01W3ycUeVrvweT3ytAoyZ76q